### PR TITLE
Add Streamlit reserving app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.streamlit/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# reserving-app
+# Reserving App
+
+A minimal Streamlit application that performs claims reserving using the
+[`chainladder`](https://pypi.org/project/chainladder/) package. The app
+can run locally or be deployed to Streamlit Cloud.
+
+## Running locally
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Launch the app:
+   ```bash
+   streamlit run app.py
+   ```
+   The interface will be available in your browser.
+
+## Deploying to Streamlit Cloud
+
+1. Push this repository to a GitHub account.
+2. Sign in to [Streamlit Cloud](https://share.streamlit.io) and create a
+   new app pointing to the GitHub repository and the `app.py` file.
+3. Streamlit Cloud will automatically install dependencies from
+   `requirements.txt` and deploy the app.
+
+## Using the app
+
+- **Triangle** tab: Upload a CSV cumulative claims triangle or explore the
+  built-in CLRD dataset. When using the sample data you can group or filter
+  triangles by company or line of business and choose which measure to analyse.
+- **LDF/CDF** tab: View loss development factors (LDFs) and cumulative
+  development factors (CDFs) alongside ultimate claims and IBNR by origin period.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,86 @@
+import pandas as pd
+import streamlit as st
+import chainladder as cl
+
+st.set_page_config(page_title="Reserving App", page_icon="📊")
+
+
+def load_uploaded_triangle(file):
+    df = pd.read_csv(file, index_col=0)
+    return cl.Triangle(df), df
+
+
+def load_sample_triangle():
+    clrd = cl.load_sample("clrd")
+    index = clrd.index
+    group_by = st.selectbox("Group by", ["Company", "Line of Business"])
+    measure = st.selectbox("Value", clrd.columns.tolist(), index=1)
+    if group_by == "Company":
+        companies = sorted(index["GRNAME"].unique())
+        company = st.selectbox("Company", companies)
+        lob_options = sorted(index.loc[index["GRNAME"] == company, "LOB"].unique())
+        lob = st.selectbox("Line of Business", lob_options)
+        triangle = clrd.loc[(company, lob), measure]
+        title = f"{measure} - {company} - {lob}"
+    else:
+        lobs = sorted(index["LOB"].unique())
+        lob = st.selectbox("Line of Business", lobs)
+        triangle = clrd.groupby("LOB").sum().loc[lob, measure]
+        title = f"{measure} - {lob}"
+    st.subheader(title)
+    st.dataframe(triangle.to_frame())
+    return triangle
+
+
+def triangle_tab():
+    st.header("Triangle Builder")
+    uploaded = st.file_uploader("Triangle CSV", type="csv")
+    if uploaded:
+        triangle, df = load_uploaded_triangle(uploaded)
+        st.subheader("Input Triangle")
+        st.dataframe(df)
+    else:
+        st.info("Using sample CLRD dataset")
+        triangle = load_sample_triangle()
+    return triangle
+
+
+def ldf_cdf_tab(triangle):
+    st.header("LDF/CDF Analysis")
+    if triangle is None:
+        st.warning("Please build a triangle in the previous tab.")
+        return
+    model = cl.Chainladder().fit(triangle)
+    display = st.multiselect("Display", ["LDF", "CDF"], default=["LDF", "CDF"])
+    if "LDF" in display:
+        ldf_values = model.ldf_.values[0, 0, 0][:-1]
+        ldfs = pd.Series(ldf_values, index=triangle.development, name="LDF")
+        st.subheader("Loss Development Factors")
+        st.dataframe(ldfs)
+    if "CDF" in display:
+        cdf_values = model.cdf_.values[0, 0, 0][:-1]
+        cdfs = pd.Series(cdf_values, index=triangle.development, name="CDF")
+        st.subheader("Cumulative Development Factors")
+        st.dataframe(cdfs)
+    st.subheader("Ultimate Claims")
+    ultimate = model.ultimate_.to_frame()
+    ultimate.columns = ["ultimate"]
+    st.dataframe(ultimate)
+    st.subheader("IBNR by Origin Period")
+    ibnr = model.ibnr_.to_frame()
+    ibnr.columns = ["ibnr"]
+    st.dataframe(ibnr)
+    st.metric("Total IBNR", f"{ibnr['ibnr'].sum():,.0f}")
+
+
+def main():
+    st.title("Chain Ladder Reserving App")
+    tabs = st.tabs(["Triangle", "LDF/CDF"])
+    with tabs[0]:
+        triangle = triangle_tab()
+    with tabs[1]:
+        ldf_cdf_tab(triangle)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+chainladder
+pandas
+streamlit


### PR DESCRIPTION
## Summary
- refactor Streamlit app into triangle-builder and LDF/CDF analysis tabs
- allow grouping or filtering sample CLRD data by company and line of business
- modularize code into reusable functions and update documentation for new flow

## Testing
- `python -m py_compile app.py`
- `python -m streamlit run app.py --server.headless true --server.port=8501`

------
https://chatgpt.com/codex/tasks/task_e_68978c306e688330aa90e56e0c983e8c