### PR TITLE
Switch to CLRD sample data and handle multi-variable triangles

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,20 +1,30 @@
 import streamlit as st
 import chainladder as cl
+import pandas as pd
 
 
 def main():
     st.title("Claims Triangle")
 
-    # Load sample data as a Triangle and retrieve the underlying tabular data
-    triangle = cl.load_sample("RAA")
-    df = triangle.to_frame(keepdims=True)
+    # Load sample data with multiple value columns and index categories
+    triangle = cl.load_sample("clrd")
+    df = triangle.to_frame().reset_index()
+
+    # Convert numeric development lags to actual evaluation dates
+    df["development"] = df.apply(
+        lambda row: row["origin"] + pd.DateOffset(months=int(row["development"])),
+        axis=1,
+    )
 
     # Identify categorical columns that can be used for grouping
     cat_cols = [
         col
         for col, dtype in df.dtypes.items()
-        if dtype == "object" and col not in ["origin", "development", "values"]
+        if dtype == "object" and col not in ["origin", "development"]
     ]
+
+    # Determine numeric value columns
+    value_cols = [col for col in df.columns if col not in ["origin", "development"] + cat_cols]
 
     # Sidebar allowing user to select grouping columns
     group_cols = st.sidebar.multiselect("Group triangles by", cat_cols)
@@ -29,12 +39,13 @@ def main():
                 data=group,
                 origin="origin",
                 development="development",
-                columns=["values"],
+                columns=value_cols,
                 index=group_cols,
+                cumulative=True,
             )
             st.dataframe(sub_triangle.to_frame())
     else:
-        st.dataframe(triangle.to_frame())
+        st.dataframe(df)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Load the CLRD sample dataset which includes multiple value columns and index categories
- Convert development lags to evaluation dates and derive grouping & value columns dynamically
- Allow grouping and display of sub-triangles with multiple variables

## Testing
- `python -m py_compile app.py`
- `python app.py` *(expected warnings about ScriptRunContext)*

------
https://chatgpt.com/codex/tasks/task_e_6897a4a4dc68833080839abbdb95e582