### PR TITLE
Add actuarial utilities and triangle extraction

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@ import streamlit as st
 import chainladder as cl
 import pandas as pd
 
+from helper_functions import ActuarialUtils
+
 
 def main():
     st.title("Claims Triangle")
@@ -23,29 +25,30 @@ def main():
         if dtype == "object" and col not in ["origin", "development"]
     ]
 
-    # Determine numeric value columns
-    value_cols = [
-        col for col in df.columns if col not in ["origin", "development"] + cat_cols
-    ]
-
-    # Sidebar allowing user to select grouping columns
+    # Sidebar allowing user to select value and grouping columns
+    value_options = ["IncurLoss", "CumPaidLoss"]
+    selected_values = st.sidebar.multiselect(
+        "Value columns", value_options, default=value_options
+    )
     group_cols = st.sidebar.multiselect("Group triangles by", cat_cols)
 
-    # Display triangles for each unique combination of selected categories
-    if group_cols:
-        for key, group in df.groupby(group_cols):
-            key_vals = key if isinstance(key, tuple) else (key,)
-            title = ", ".join(f"{col}={val}" for col, val in zip(group_cols, key_vals))
-            st.subheader(title)
-            sub_triangle = cl.Triangle(
-                data=group,
-                origin="origin",
-                development="development",
-                columns=value_cols,
-                index=group_cols,
-                cumulative=True,
-            )
-            st.dataframe(sub_triangle.to_frame())
+    utils = ActuarialUtils()
+    utils.create_triangle(
+        df,
+        origin="origin",
+        development="development",
+        value_cols=selected_values,
+        group_cols=group_cols,
+        cumulative=True,
+    )
+    triangles = utils.extract_triangle_dfs()
+
+    for (group_title, val_col), tri_df in triangles.items():
+        title_parts = [val_col]
+        if group_title:
+            title_parts.insert(0, group_title)
+        st.subheader(" - ".join(title_parts))
+        st.dataframe(tri_df)
 
 
 if __name__ == "__main__":

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -1,0 +1,75 @@
+import chainladder as cl
+import pandas as pd
+from typing import Dict, List, Optional, Tuple
+
+
+class ActuarialUtils:
+    """Utility helpers for actuarial reserving tasks."""
+
+    def __init__(self) -> None:
+        self.triangle: Optional[cl.Triangle] = None
+
+    def create_triangle(
+        self,
+        data: pd.DataFrame,
+        origin: str = "origin",
+        development: str = "development",
+        value_cols: Optional[List[str]] = None,
+        group_cols: Optional[List[str]] = None,
+        cumulative: bool = True,
+    ) -> cl.Triangle:
+        """Create and store a ``chainladder.Triangle`` from ``data``."""
+
+        value_cols = value_cols or [
+            col
+            for col in data.columns
+            if col not in [origin, development] + (group_cols or [])
+        ]
+
+        self.triangle = cl.Triangle(
+            data=data,
+            origin=origin,
+            development=development,
+            columns=value_cols,
+            index=group_cols,
+            cumulative=cumulative,
+        )
+        return self.triangle
+
+    def extract_triangle_dfs(
+        self,
+    ) -> Dict[Tuple[Optional[str], str], pd.DataFrame]:
+        """Return DataFrames for each value column and group combination.
+
+        ``create_triangle`` must be called before invoking this method. The
+        stored triangle is split into a dictionary keyed by ``(group_key,
+        value_col)`` where ``group_key`` is a formatted string of the grouping
+        column values or ``None`` when no grouping columns were supplied.
+        """
+
+        if self.triangle is None:
+            raise ValueError("No triangle available. Call create_triangle first.")
+
+        df = self.triangle.to_frame().reset_index()
+        origin = self.triangle.origin
+        development = self.triangle.development
+        group_cols = [name for name in self.triangle.index.names if name is not None]
+        value_cols = list(self.triangle.columns)
+
+        triangles: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
+        if group_cols:
+            for key, grp in df.groupby(group_cols):
+                key_vals = key if isinstance(key, tuple) else (key,)
+                group_title = ", ".join(
+                    f"{col}={val}" for col, val in zip(group_cols, key_vals)
+                )
+                for val_col in value_cols:
+                    pivot = grp.pivot(
+                        index=origin, columns=development, values=val_col
+                    )
+                    triangles[(group_title, val_col)] = pivot
+        else:
+            for val_col in value_cols:
+                pivot = df.pivot(index=origin, columns=development, values=val_col)
+                triangles[(None, val_col)] = pivot
+        return triangles


### PR DESCRIPTION
## Summary
- add `ActuarialUtils` helper class for creating triangles and extracting triangle dataframes
- allow selecting value metrics and grouping columns in the Streamlit app
- cache triangles on creation and reuse for extraction

## Testing
- `python -m py_compile app.py helper_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_6897acbe9cf8833081196067eb1589a8