### PR TITLE
Fix Chainladder triangle index access

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -66,13 +66,15 @@ class ActuarialUtils:
 
         triangles: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
         if group_cols:
-            unique_groups = index_df.drop_duplicates()
+            unique_groups = index_df[group_cols].drop_duplicates()
             for row in unique_groups.itertuples(index=False, name=None):
-                selector = dict(zip(group_cols, row))
+                mask = pd.Series(True, index=self.triangle.index)
+                for col, val in zip(group_cols, row):
+                    mask &= self.triangle[col] == val
                 group_title = ", ".join(
                     f"{col}={val}" for col, val in zip(group_cols, row)
                 )
-                sub_tri = self.triangle[selector]
+                sub_tri = self.triangle[mask]
                 for val_col in value_cols:
                     triangles[(group_title, val_col)] = sub_tri[val_col].to_frame()
         else:

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -53,7 +53,19 @@ class ActuarialUtils:
         df = self.triangle.to_frame().reset_index()
         origin = self.triangle.origin
         development = self.triangle.development
-        group_cols = [name for name in self.triangle.index.names if name is not None]
+
+        # ``chainladder.Triangle`` exposes its grouping keys via a DataFrame on the
+        # ``index`` attribute rather than a ``MultiIndex``.  Attempting to access
+        # ``index.names`` therefore raises ``AttributeError``.  Instead, rely on the
+        # DataFrame column labels and drop the synthetic ``Total`` column that
+        # Chainladder adds when no explicit grouping columns are supplied.
+        index_df = self.triangle.index
+        group_cols = [
+            col
+            for col in index_df.columns
+            if not (col == "Total" and index_df[col].nunique() == 1)
+        ]
+
         value_cols = list(self.triangle.columns)
 
         triangles: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -68,13 +68,12 @@ class ActuarialUtils:
         if group_cols:
             unique_groups = index_df[group_cols].drop_duplicates()
             for row in unique_groups.itertuples(index=False, name=None):
-                mask = pd.Series(True, index=self.triangle.index)
+                sub_tri = self.triangle
                 for col, val in zip(group_cols, row):
-                    mask &= self.triangle[col] == val
+                    sub_tri = sub_tri[sub_tri[col] == val]
                 group_title = ", ".join(
                     f"{col}={val}" for col, val in zip(group_cols, row)
                 )
-                sub_tri = self.triangle[mask]
                 for val_col in value_cols:
                     triangles[(group_title, val_col)] = sub_tri[val_col].to_frame()
         else:

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -50,10 +50,6 @@ class ActuarialUtils:
         if self.triangle is None:
             raise ValueError("No triangle available. Call create_triangle first.")
 
-        df = self.triangle.to_frame().reset_index()
-        origin = self.triangle.origin
-        development = self.triangle.development
-
         # ``chainladder.Triangle`` exposes its grouping keys via a DataFrame on the
         # ``index`` attribute rather than a ``MultiIndex``.  Attempting to access
         # ``index.names`` therefore raises ``AttributeError``.  Instead, rely on the
@@ -70,18 +66,16 @@ class ActuarialUtils:
 
         triangles: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
         if group_cols:
-            for key, grp in df.groupby(group_cols):
-                key_vals = key if isinstance(key, tuple) else (key,)
+            unique_groups = index_df.drop_duplicates()
+            for row in unique_groups.itertuples(index=False, name=None):
+                selector = dict(zip(group_cols, row))
                 group_title = ", ".join(
-                    f"{col}={val}" for col, val in zip(group_cols, key_vals)
+                    f"{col}={val}" for col, val in zip(group_cols, row)
                 )
+                sub_tri = self.triangle[selector]
                 for val_col in value_cols:
-                    pivot = grp.pivot(
-                        index=origin, columns=development, values=val_col
-                    )
-                    triangles[(group_title, val_col)] = pivot
+                    triangles[(group_title, val_col)] = sub_tri[val_col].to_frame()
         else:
             for val_col in value_cols:
-                pivot = df.pivot(index=origin, columns=development, values=val_col)
-                triangles[(None, val_col)] = pivot
+                triangles[(None, val_col)] = self.triangle[val_col].to_frame()
         return triangles


### PR DESCRIPTION
## Summary
- handle Chainladder Triangle index DataFrame instead of MultiIndex
- filter out synthetic 'Total' column when no grouping columns provided

## Testing
- `python -m py_compile helper_functions.py`
- `python app.py` *(fails: AttributeError: module 'llvmlite.binding' has no attribute 'get_host_cpu_name')*


------
https://chatgpt.com/codex/tasks/task_e_6897b222c12c8330910e6cb29a3d2171