### PR TITLE
Add ATA and development factor tables to triangle view

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,13 +82,17 @@ def main() -> None:
                 st.dataframe(tri.link_ratio.to_frame())
                 dev_vol = utils.fit_development_model(tri)
                 dev_simp = utils.fit_development_model(tri, average="simple")
-                ldf_vol = dev_vol.ldf_.to_frame(); ldf_vol.index = ["Volume Weighted"]
-                ldf_simp = dev_simp.ldf_.to_frame(); ldf_simp.index = ["Simple Average"]
+                ldf_vol = dev_vol.ldf_.to_frame()
+                ldf_vol.index = ["Volume Weighted"]
+                ldf_simp = dev_simp.ldf_.to_frame()
+                ldf_simp.index = ["Simple Average"]
                 ldf_table = pd.concat([ldf_vol, ldf_simp])
                 st.markdown("**LDFs**")
                 st.dataframe(ldf_table)
-                cdf_vol = dev_vol.cdf_.to_frame(); cdf_vol.index = ["Volume Weighted"]
-                cdf_simp = dev_simp.cdf_.to_frame(); cdf_simp.index = ["Simple Average"]
+                cdf_vol = dev_vol.cdf_.to_frame()
+                cdf_vol.index = ["Volume Weighted"]
+                cdf_simp = dev_simp.cdf_.to_frame()
+                cdf_simp.index = ["Simple Average"]
                 cdf_table = pd.concat([cdf_vol, cdf_simp])
                 st.markdown("**CDFs**")
                 st.dataframe(cdf_table)

--- a/app.py
+++ b/app.py
@@ -53,21 +53,21 @@ def main() -> None:
         group_cols=group_cols,
         cumulative=True,
     )
-    triangles = utils.extract_triangle_dfs()
+    triangles = utils.extract_triangles()
 
     # Restructure triangles so that each grouping combination renders its
     # associated value column triangles together rather than as individual
     # entries.  ``triangles`` is keyed by ``(group_title, value_col)``; group
     # them by ``group_title`` first, then iterate the value columns within
     # each group.
-    grouped: dict[str | None, dict[str, pd.DataFrame]] = {}
-    for (group_title, val_col), tri_df in triangles.items():
-        grouped.setdefault(group_title, {})[val_col] = tri_df
+    grouped: dict[str | None, dict[str, cl.Triangle]] = {}
+    for (group_title, val_col), tri in triangles.items():
+        grouped.setdefault(group_title, {})[val_col] = tri
 
     for group_title, val_map in grouped.items():
         if group_title is not None:
             st.subheader(group_title)
-        for val_col, tri_df in val_map.items():
+        for val_col, tri in val_map.items():
             # When no grouping columns are supplied, the value column itself
             # should serve as the subheader.  Otherwise, display the value
             # column as a caption within the group section.
@@ -75,7 +75,23 @@ def main() -> None:
                 st.subheader(val_col)
             else:
                 st.markdown(f"**{val_col}**")
-            st.dataframe(tri_df)
+            value_tab, ata_tab = st.tabs(["Values", "ATA"])
+            with value_tab:
+                st.dataframe(tri.to_frame())
+            with ata_tab:
+                st.dataframe(tri.link_ratio.to_frame())
+                dev_vol = utils.fit_development_model(tri)
+                dev_simp = utils.fit_development_model(tri, average="simple")
+                ldf_vol = dev_vol.ldf_.to_frame(); ldf_vol.index = ["Volume Weighted"]
+                ldf_simp = dev_simp.ldf_.to_frame(); ldf_simp.index = ["Simple Average"]
+                ldf_table = pd.concat([ldf_vol, ldf_simp])
+                st.markdown("**LDFs**")
+                st.dataframe(ldf_table)
+                cdf_vol = dev_vol.cdf_.to_frame(); cdf_vol.index = ["Volume Weighted"]
+                cdf_simp = dev_simp.cdf_.to_frame(); cdf_simp.index = ["Simple Average"]
+                cdf_table = pd.concat([cdf_vol, cdf_simp])
+                st.markdown("**CDFs**")
+                st.dataframe(cdf_table)
         st.write("---")
 
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -80,3 +80,76 @@ class ActuarialUtils:
             for val_col in value_cols:
                 triangles[(None, val_col)] = self.triangle[val_col].to_frame()
         return triangles
+
+    def extract_triangles(
+        self,
+    ) -> Dict[Tuple[Optional[str], str], cl.Triangle]:
+        """Return ``chainladder.Triangle`` objects for each subgroup.
+
+        The keys of the returned dictionary match those from
+        :meth:`extract_triangle_dfs` but the values are the underlying
+        ``chainladder.Triangle`` instances rather than the DataFrame
+        representation.  This is helpful for computing age‑to‑age factors
+        and development statistics without repeatedly converting between
+        object types.
+        """
+
+        if self.triangle is None:
+            raise ValueError("No triangle available. Call create_triangle first.")
+
+        index_df = self.triangle.index
+        group_cols = [
+            col
+            for col in index_df.columns
+            if not (col == "Total" and index_df[col].nunique() == 1)
+        ]
+
+        value_cols = list(self.triangle.columns)
+
+        triangles: Dict[Tuple[Optional[str], str], cl.Triangle] = {}
+        if group_cols:
+            unique_groups = index_df[group_cols].drop_duplicates()
+            for row in unique_groups.itertuples(index=False, name=None):
+                sub_tri = self.triangle
+                for col, val in zip(group_cols, row):
+                    sub_tri = sub_tri[sub_tri[col] == val]
+                group_title = ", ".join(
+                    f"{col}={val}" for col, val in zip(group_cols, row)
+                )
+                for val_col in value_cols:
+                    triangles[(group_title, val_col)] = sub_tri[val_col]
+        else:
+            for val_col in value_cols:
+                triangles[(None, val_col)] = self.triangle[val_col]
+        return triangles
+
+    def fit_development_model(
+        self,
+        triangle: cl.Triangle,
+        development_method: str = "chainladder",
+        **kwargs,
+    ) -> cl.Development:
+        """Fit a development model to ``triangle``.
+
+        Parameters
+        ----------
+        triangle:
+            The :class:`chainladder.Triangle` to model.
+        development_method:
+            The development technique to apply. Currently only ``"chainladder"``
+            is supported.
+        **kwargs:
+            Additional keyword arguments forwarded to the underlying
+            ``chainladder`` development model.
+
+        Returns
+        -------
+        chainladder.Development
+            The fitted development model instance.
+        """
+
+        if development_method != "chainladder":
+            raise NotImplementedError(
+                f"Development method '{development_method}' is not implemented."
+            )
+        return cl.Development(**kwargs).fit(triangle)


### PR DESCRIPTION
## Summary
- Show value and ATA triangles in separate tabs
- Display volume-weighted and simple-average LDF and CDF tables below each ATA triangle
- Provide utility to extract sub-triangle objects for development analysis
- Add `fit_development_model` helper to wrap chainladder development fitting

## Testing
- `python -m py_compile app.py helper_functions.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897cd1fe9d08330b2c89873ae0c820f