### PR TITLE
Refactor triangle utilities and add dev factor exhibits

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import chainladder as cl
 import pandas as pd
 import streamlit as st
 
-from helper_functions import ReservingAppTriangle
+from helper_functions import *
 
 
 def process_data() -> tuple[pd.DataFrame, list[str]]:

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import chainladder as cl
 import pandas as pd
 import streamlit as st
 
-from helper_functions import ActuarialUtils
+from helper_functions import ReservingAppTriangle
 
 
 def process_data() -> tuple[pd.DataFrame, list[str]]:
@@ -44,8 +44,7 @@ def main() -> None:
     df, cat_cols = process_data()
     selected_values, group_cols = render_sidebar(cat_cols)
 
-    utils = ActuarialUtils()
-    utils.create_triangle(
+    utils = ReservingAppTriangle(
         df,
         origin="origin",
         development="development",
@@ -53,7 +52,7 @@ def main() -> None:
         group_cols=group_cols,
         cumulative=True,
     )
-    triangles = utils.extract_triangles()
+    triangles = utils.triangles
 
     # Restructure triangles so that each grouping combination renders its
     # associated value column triangles together rather than as individual
@@ -80,22 +79,10 @@ def main() -> None:
                 st.dataframe(tri.to_frame())
             with ata_tab:
                 st.dataframe(tri.link_ratio.to_frame())
-                dev_vol = utils.fit_development_model(tri)
-                dev_simp = utils.fit_development_model(tri, average="simple")
-                ldf_vol = dev_vol.ldf_.to_frame()
-                ldf_vol.index = ["Volume Weighted"]
-                ldf_simp = dev_simp.ldf_.to_frame()
-                ldf_simp.index = ["Simple Average"]
-                ldf_table = pd.concat([ldf_vol, ldf_simp])
                 st.markdown("**LDFs**")
-                st.dataframe(ldf_table)
-                cdf_vol = dev_vol.cdf_.to_frame()
-                cdf_vol.index = ["Volume Weighted"]
-                cdf_simp = dev_simp.cdf_.to_frame()
-                cdf_simp.index = ["Simple Average"]
-                cdf_table = pd.concat([cdf_vol, cdf_simp])
+                st.dataframe(utils.ldf_exhibit[(group_title, val_col)])
                 st.markdown("**CDFs**")
-                st.dataframe(cdf_table)
+                st.dataframe(utils.cdf_exhibit[(group_title, val_col)])
         st.write("---")
 
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -3,11 +3,40 @@ import pandas as pd
 from typing import Dict, List, Optional, Tuple
 
 
-class ActuarialUtils:
-    """Utility helpers for actuarial reserving tasks."""
+class ReservingAppTriangle:
+    """Utility helpers for actuarial reserving tasks.
 
-    def __init__(self) -> None:
-        self.triangle: Optional[cl.Triangle] = None
+    On instantiation this class immediately builds a ``chainladder`` triangle
+    from the provided data, extracts each subgroup as a DataFrame and computes
+    development factor exhibits.  The resulting artifacts are exposed via the
+    ``triangle`` ``triangle_dfs``, ``triangles``, ``ldf_exhibit`` and
+    ``cdf_exhibit`` attributes.
+    """
+
+    def __init__(
+        self,
+        data: pd.DataFrame,
+        origin: str = "origin",
+        development: str = "development",
+        value_cols: Optional[List[str]] = None,
+        group_cols: Optional[List[str]] = None,
+        cumulative: bool = True,
+    ) -> None:
+        # Build and store the master triangle
+        self.triangle: cl.Triangle = self.create_triangle(
+            data,
+            origin=origin,
+            development=development,
+            value_cols=value_cols,
+            group_cols=group_cols,
+            cumulative=cumulative,
+        )
+
+        # Split into DataFrame and Triangle representations for each subgroup
+        self.triangle_dfs = self.extract_triangle_dfs()
+
+        # Compute development factor exhibits for each subgroup
+        self.get_dev_factor_exhibit()
 
     def create_triangle(
         self,
@@ -123,28 +152,36 @@ class ActuarialUtils:
                 triangles[(None, val_col)] = self.triangle[val_col]
         return triangles
 
-    def fit_development_model(
-        self,
-        triangle: cl.Triangle,
-        **kwargs,
-    ) -> cl.Development:
-        """Fit a development model to ``triangle``.
+    def get_dev_factor_exhibit(self) -> None:
+        """Generate LDF and CDF exhibits for each subgroup.
 
-        Parameters
-        ----------
-        triangle:
-            The :class:`chainladder.Triangle` to model.
-        development_method:
-            The development technique to apply. Currently only ``"chainladder"``
-            is supported.
-        **kwargs:
-            Additional keyword arguments forwarded to the underlying
-            ``chainladder`` development model.
-
-        Returns
-        -------
-        chainladder.Development
-            The fitted development model instance.
+        This method fits both volume weighted and simple average development
+        models to every triangle produced by :meth:`extract_triangles`.  The
+        resulting LDF and CDF tables are stored on ``ldf_exhibit`` and
+        ``cdf_exhibit`` dictionaries keyed by ``(group_title, value_col)``.
+        The underlying ``chainladder.Triangle`` objects are also stored on the
+        ``triangles`` attribute for easy access when rendering link ratios.
         """
 
-        return cl.Development(**kwargs).fit(triangle)
+        if self.triangle is None:
+            raise ValueError("No triangle available. Call create_triangle first.")
+
+        self.triangles = self.extract_triangles()
+        self.ldf_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
+        self.cdf_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
+
+        for key, tri in self.triangles.items():
+            dev_vol = cl.Development().fit(tri)
+            dev_simp = cl.Development(average="simple").fit(tri)
+
+            ldf_vol = dev_vol.ldf_.to_frame()
+            ldf_vol.index = ["Volume Weighted"]
+            ldf_simp = dev_simp.ldf_.to_frame()
+            ldf_simp.index = ["Simple Average"]
+            self.ldf_exhibit[key] = pd.concat([ldf_vol, ldf_simp])
+
+            cdf_vol = dev_vol.cdf_.to_frame()
+            cdf_vol.index = ["Volume Weighted"]
+            cdf_simp = dev_simp.cdf_.to_frame()
+            cdf_simp.index = ["Simple Average"]
+            self.cdf_exhibit[key] = pd.concat([cdf_vol, cdf_simp])


### PR DESCRIPTION
## Summary
- rename `ActuarialUtils` to `ReservingAppTriangle` and automatically build triangles on init
- compute LDF and CDF exhibits via new `get_dev_factor_exhibit` method
- streamline app to use precomputed development factor exhibits

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897d9e19bd483308d5fe404576bcff4