### PR TITLE
Add reserve exhibit tab with Chainladder ultimates

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,6 +52,7 @@ def main() -> None:
         group_cols=group_cols,
         cumulative=True,
     )
+    utils.fit_development_model()
     triangles = utils.triangles
 
     # Restructure triangles so that each grouping combination renders its
@@ -74,7 +75,7 @@ def main() -> None:
                 st.subheader(val_col)
             else:
                 st.markdown(f"**{val_col}**")
-            value_tab, ata_tab = st.tabs(["Values", "ATA"])
+            value_tab, ata_tab, reserve_tab = st.tabs(["Values", "ATA", "Reserve Exhibit"])
             with value_tab:
                 st.dataframe(tri.to_frame())
             with ata_tab:
@@ -83,6 +84,8 @@ def main() -> None:
                 st.dataframe(utils.ldf_exhibit[(group_title, val_col)])
                 st.markdown("**CDFs**")
                 st.dataframe(utils.cdf_exhibit[(group_title, val_col)])
+            with reserve_tab:
+                st.dataframe(utils.reserve_exhibit[(group_title, val_col)])
         st.write("---")
 
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -185,3 +185,29 @@ class ReservingAppTriangle:
             cdf_simp = dev_simp.cdf_.to_frame()
             cdf_simp.index = ["Simple Average"]
             self.cdf_exhibit[key] = pd.concat([cdf_vol, cdf_simp])
+
+    def fit_development_model(self, development_method: str = "chainladder") -> None:
+        """Fit a development model and store resulting exhibits.
+
+        Currently supports only the deterministic Chainladder method.  For each
+        triangle derived from :meth:`extract_triangles`, a ``Pipeline`` is used
+        to fit the selected development model and the ultimate losses by origin
+        year are captured on the ``reserve_exhibit`` attribute.
+        """
+
+        if not hasattr(self, "triangles"):
+            self.triangles = self.extract_triangles()
+
+        self.reserve_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
+
+        for key, tri in self.triangles.items():
+            if development_method.lower() == "chainladder":
+                pipe = cl.Pipeline([("chainladder", cl.Chainladder())]).fit(tri)
+                ultimate_df = pipe["chainladder"].ultimate_.to_frame()
+                if len(ultimate_df.columns) == 1:
+                    ultimate_df.columns = ["Ultimate"]
+                self.reserve_exhibit[key] = ultimate_df
+            else:
+                raise ValueError(
+                    f"Unsupported development method: {development_method}"
+                )


### PR DESCRIPTION
## Summary
- add `fit_development_model` to build Chainladder models and capture ultimate tables
- extend Streamlit UI with new Reserve Exhibit tab

## Testing
- `python -m py_compile app.py helper_functions.py`
- `python - <<'PY'
import chainladder as cl
import pandas as pd
from helper_functions import ReservingAppTriangle
triangle = cl.load_sample('clrd')
df = triangle.to_frame().reset_index()
df['development'] = df.apply(lambda row: row['origin'] + pd.DateOffset(months=int(row['development']) - 12), axis=1)
utils = ReservingAppTriangle(df, origin='origin', development='development', value_cols=['IncurLoss'], group_cols=['GRNAME','LOB'], cumulative=True)
utils.fit_development_model()
key = list(utils.reserve_exhibit.keys())[0]
print('sample reserve exhibit for', key)
print(utils.reserve_exhibit[key].head())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6897df64bb8c8330a7d31f07aec99b21