### PR TITLE
feat: add AG Grid helper and display

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 streamlit = "*"
 chainladder = "*"
 colorama = "*"
+streamlit-aggrid = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e31fc9df17240d2c17620d8b493411245976b150e43fc98ee80597c1ababa9a9"
+            "sha256": "14fb4602f2f91b33b3240b2ab33a4e12250d574d3a4f6a1fdb0654b866c12bbd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -963,8 +963,15 @@
                 "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.9.0.post0"
+        },
+        "python-decouple": {
+            "hashes": [
+                "sha256:ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f",
+                "sha256:d0d45340815b25f4de59c974b855bb38d03151d81b037d9e3f463b0c9f8cbd66"
+            ],
+            "version": "==3.8"
         },
         "pytz": {
             "hashes": [
@@ -1248,7 +1255,7 @@
                 "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
                 "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.17.0"
         },
         "smmap": {
@@ -1276,6 +1283,15 @@
             "markers": "python_version >= '3.9' and python_full_version != '3.9.7'",
             "version": "==1.48.0"
         },
+        "streamlit-aggrid": {
+            "hashes": [
+                "sha256:27bf8b04b09a2f10a4030168c1ac9bea2b262254765e6ba77f72bf42ad004a2e",
+                "sha256:c4e761631b0c91b6dbc9da618f1bbf22e201e4041e4d9e3b17e55e5cb44dc8b0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.10'",
+            "version": "==1.1.7"
+        },
         "tenacity": {
             "hashes": [
                 "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb",
@@ -1297,7 +1313,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==0.10.2"
         },
         "tornado": {
@@ -1375,7 +1391,7 @@
                 "sha256:e7631a77ffb1f7d2eefa4445ebbee491c720a5661ddf6df3498ebecae5ed375c",
                 "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2"
             ],
-            "markers": "platform_system != 'Darwin'",
+            "markers": "python_version >= '3.9'",
             "version": "==6.0.0"
         }
     },

--- a/app.py
+++ b/app.py
@@ -77,15 +77,15 @@ def main() -> None:
                 st.markdown(f"**{val_col}**")
             value_tab, ata_tab, reserve_tab = st.tabs(["Values", "ATA", "Reserve Exhibit"])
             with value_tab:
-                st.dataframe(tri.to_frame())
+                custom_aggrid(tri.to_frame())
             with ata_tab:
-                st.dataframe(tri.link_ratio.to_frame())
+                custom_aggrid(tri.link_ratio.to_frame())
                 st.markdown("**LDFs**")
-                st.dataframe(utils.ldf_exhibit[(group_title, val_col)])
+                custom_aggrid(utils.ldf_exhibit[(group_title, val_col)])
                 st.markdown("**CDFs**")
-                st.dataframe(utils.cdf_exhibit[(group_title, val_col)])
+                custom_aggrid(utils.cdf_exhibit[(group_title, val_col)])
             with reserve_tab:
-                st.dataframe(utils.reserve_exhibit[(group_title, val_col)])
+                custom_aggrid(utils.reserve_exhibit[(group_title, val_col)])
         st.write("---")
 
 

--- a/app.py
+++ b/app.py
@@ -77,15 +77,15 @@ def main() -> None:
                 st.markdown(f"**{val_col}**")
             value_tab, ata_tab, reserve_tab = st.tabs(["Values", "ATA", "Reserve Exhibit"])
             with value_tab:
-                custom_aggrid(tri.to_frame())
+                custom_aggrid(tri.to_frame(), index_label="Year")
             with ata_tab:
-                custom_aggrid(tri.link_ratio.to_frame())
+                custom_aggrid(tri.link_ratio.to_frame(), index_label="Year")
                 st.markdown("**LDFs**")
-                custom_aggrid(utils.ldf_exhibit[(group_title, val_col)])
+                custom_aggrid(utils.ldf_exhibit[(group_title, val_col)], index_label="Year")
                 st.markdown("**CDFs**")
-                custom_aggrid(utils.cdf_exhibit[(group_title, val_col)])
+                custom_aggrid(utils.cdf_exhibit[(group_title, val_col)], index_label="Year")
             with reserve_tab:
-                custom_aggrid(utils.reserve_exhibit[(group_title, val_col)])
+                custom_aggrid(utils.reserve_exhibit[(group_title, val_col)], index_label="Year")
         st.write("---")
 
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -8,6 +8,10 @@ from st_aggrid import AgGrid, GridOptionsBuilder, JsCode
 def custom_aggrid(df: pd.DataFrame) -> dict:
     """Display ``df`` using AG Grid with numeric formatting.
 
+    The index is rendered as standard columns so that it appears in the grid
+    output.  All column labels are coerced to strings to avoid JavaScript
+    errors when numeric column names are encountered.
+
     Numeric columns are formatted depending on whether their absolute maximum
     value exceeds 999. Values greater than this threshold are shown with a
     thousands separator and no decimals. Otherwise values are displayed with
@@ -25,8 +29,19 @@ def custom_aggrid(df: pd.DataFrame) -> dict:
         Response returned by :func:`st_aggrid.AgGrid`.
     """
 
+    # Display the index as regular columns and ensure all column labels are
+    # strings so that AG Grid's internal string operations do not fail on
+    # numeric names.
+    index_levels = df.index.nlevels
+    df = df.reset_index()
+    df.columns = df.columns.map(str)
+
     gb = GridOptionsBuilder.from_dataframe(df)
     numeric_cols = df.select_dtypes(include="number").columns
+    # Exclude index columns from numeric formatting to preserve values like
+    # "1990" without thousands separators.
+    index_cols = df.columns[:index_levels]
+    numeric_cols = [col for col in numeric_cols if col not in index_cols]
     for col in numeric_cols:
         max_val = df[col].abs().max()
         if max_val > 999:

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Optional, Tuple
 from st_aggrid import AgGrid, GridOptionsBuilder, JsCode
 
 
-def custom_aggrid(df: pd.DataFrame) -> dict:
+def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
     """Display ``df`` using AG Grid with numeric formatting.
 
     The index is rendered as standard columns so that it appears in the grid
@@ -22,6 +22,9 @@ def custom_aggrid(df: pd.DataFrame) -> dict:
     ----------
     df:
         DataFrame to render.
+    index_label:
+        Optional name to use for the index column once rendered.  When
+        provided, this replaces the existing index name after reset.
 
     Returns
     -------
@@ -35,6 +38,8 @@ def custom_aggrid(df: pd.DataFrame) -> dict:
     index_levels = df.index.nlevels
     df = df.reset_index()
     df.columns = df.columns.map(str)
+    if index_label is not None and index_levels >= 1:
+        df.rename(columns={df.columns[0]: index_label}, inplace=True)
 
     gb = GridOptionsBuilder.from_dataframe(df)
     numeric_cols = df.select_dtypes(include="number").columns
@@ -56,7 +61,8 @@ def custom_aggrid(df: pd.DataFrame) -> dict:
         gb.configure_column(col, type=["numericColumn"], valueFormatter=formatter)
 
     grid_options = gb.build()
-    return AgGrid(df, gridOptions=grid_options, allow_unsafe_jscode=True)
+    row_data = df.to_dict("records")
+    return AgGrid(row_data, gridOptions=grid_options, allow_unsafe_jscode=True)
 
 
 class ReservingAppTriangle:

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -61,8 +61,12 @@ def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
         gb.configure_column(col, type=["numericColumn"], valueFormatter=formatter)
 
     grid_options = gb.build()
-    row_data = df.to_dict("records")
-    return AgGrid(row_data, gridOptions=grid_options, allow_unsafe_jscode=True)
+    # ``AgGrid`` attempts to serialize the ``data`` argument via ``DataFrame``
+    # ``to_json`` which can hit recursion limits for certain inputs.  Instead,
+    # supply the row data directly in the grid options and invoke ``AgGrid``
+    # without the ``data`` parameter to bypass that internal conversion.
+    grid_options["rowData"] = df.to_dict("records")
+    return AgGrid(gridOptions=grid_options, allow_unsafe_jscode=True)
 
 
 class ReservingAppTriangle:

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -2,6 +2,47 @@ import chainladder as cl
 import pandas as pd
 from typing import Dict, List, Optional, Tuple
 
+from st_aggrid import AgGrid, GridOptionsBuilder, JsCode
+
+
+def custom_aggrid(df: pd.DataFrame) -> dict:
+    """Display ``df`` using AG Grid with numeric formatting.
+
+    Numeric columns are formatted depending on whether their absolute maximum
+    value exceeds 999. Values greater than this threshold are shown with a
+    thousands separator and no decimals. Otherwise values are displayed with
+    two decimal places. Sorting remains based on the underlying numeric value
+    via ``valueFormatter`` JavaScript functions.
+
+    Parameters
+    ----------
+    df:
+        DataFrame to render.
+
+    Returns
+    -------
+    dict
+        Response returned by :func:`st_aggrid.AgGrid`.
+    """
+
+    gb = GridOptionsBuilder.from_dataframe(df)
+    numeric_cols = df.select_dtypes(include="number").columns
+    for col in numeric_cols:
+        max_val = df[col].abs().max()
+        if max_val > 999:
+            formatter = JsCode(
+                "function(params) {return Number(params.value).toLocaleString('en-US');}"
+            )
+        else:
+            formatter = JsCode(
+                "function(params) {return Number(params.value).toLocaleString('en-US', "
+                "{minimumFractionDigits:2, maximumFractionDigits:2});}"
+            )
+        gb.configure_column(col, type=["numericColumn"], valueFormatter=formatter)
+
+    grid_options = gb.build()
+    return AgGrid(df, gridOptions=grid_options, allow_unsafe_jscode=True)
+
 
 class ReservingAppTriangle:
     """Utility helpers for actuarial reserving tasks.

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -1,8 +1,59 @@
 import chainladder as cl
 import pandas as pd
 from typing import Dict, List, Optional, Tuple
-
+import streamlit as st
+from pandas.api.types import (
+    is_period_dtype,
+    is_datetime64_any_dtype,
+    is_integer_dtype,
+    is_string_dtype,
+)
 from st_aggrid import AgGrid, GridOptionsBuilder, JsCode
+
+
+def _coerce_year_column(df: pd.DataFrame, colname: str = "Year") -> pd.DataFrame:
+    df = df.copy()
+
+    # ensure "Year" exists (might be in the index)
+    if colname not in df.columns:
+        df = df.reset_index().rename(columns={"index": colname})
+
+    col = df[colname]
+
+    if is_period_dtype(col):
+        # Period -> timestamp -> year
+        y = col.dt.to_timestamp().dt.year
+    elif is_datetime64_any_dtype(col):
+        # datetime64[ns] (or tz-aware)
+        y = (
+            col.dt.tz_localize(None) if getattr(col.dt, "tz", None) is not None else col
+        ).dt.year
+    else:
+        # try to parse strings/numbers into datetimes; if that fails, fall back to numeric year
+        parsed = pd.to_datetime(col, errors="coerce")
+        if parsed.notna().any():
+            y = parsed.dt.year
+        else:
+            y = pd.to_numeric(col, errors="coerce")
+
+    # keep nullable ints so missing years don’t crash
+    df[colname] = y.astype("Int64")
+    return df
+
+
+def _json_safe(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    AgGrid sends data as JSON; JSON can't contain NaN/Infinity/<NA>.
+    Convert all missing to None and avoid NumPy scalars that serialize to NaN.
+    """
+    df = df.copy()
+    # Convert pandas NA/NaN to None
+    df = df.where(df.notna(), None)
+    # Make sure nullable integers don’t re-emit NaN; cast each column to Python objects
+    for c in df.columns:
+        if pd.api.types.is_integer_dtype(df[c]) and str(df[c].dtype).startswith("Int"):
+            df[c] = df[c].astype(object)  # keeps None for missing
+    return df
 
 
 def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
@@ -41,6 +92,8 @@ def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
     if index_label is not None and index_levels >= 1:
         df.rename(columns={df.columns[0]: index_label}, inplace=True)
 
+    df = _coerce_year_column(df, index_label)
+    df = _json_safe(df)
     gb = GridOptionsBuilder.from_dataframe(df)
     numeric_cols = df.select_dtypes(include="number").columns
     # Exclude index columns from numeric formatting to preserve values like
@@ -65,8 +118,8 @@ def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
     # ``to_json`` which can hit recursion limits for certain inputs.  Instead,
     # supply the row data directly in the grid options and invoke ``AgGrid``
     # without the ``data`` parameter to bypass that internal conversion.
-    grid_options["rowData"] = df.to_dict("records")
-    return AgGrid(gridOptions=grid_options, allow_unsafe_jscode=True)
+
+    return AgGrid(df, gridOptions=grid_options, allow_unsafe_jscode=True)
 
 
 class ReservingAppTriangle:


### PR DESCRIPTION
## Summary
- add `custom_aggrid` helper that formats numeric columns with thousands separators or two decimals
- display all tables using AG Grid instead of `st.dataframe`
- include `streamlit-aggrid` dependency

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897f3dff90c83308ab7261515e7c93d