### PR TITLE
Add premium dropdown and extend reserve exhibit

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,12 +5,8 @@ import streamlit as st
 from helper_functions import *
 
 
-def process_data() -> tuple[pd.DataFrame, list[str]]:
-    """Load sample data and derive categorical columns for grouping.
-
-    Returns a tuple of the processed DataFrame and a list of categorical
-    column names that can be used for grouping in the sidebar.
-    """
+def process_data() -> tuple[pd.DataFrame, list[str], list[str]]:
+    """Load sample data and derive categorical and premium columns."""
 
     triangle = cl.load_sample("clrd")
     df = triangle.to_frame().reset_index()
@@ -23,10 +19,13 @@ def process_data() -> tuple[pd.DataFrame, list[str]]:
         for col, dtype in df.dtypes.items()
         if dtype == "object" and col not in ["origin", "development"]
     ]
-    return df, cat_cols
+    prem_cols = [col for col in df.columns if "prem" in col.lower()]
+    return df, cat_cols, prem_cols
 
 
-def render_sidebar(cat_cols: list[str]) -> tuple[list[str], list[str]]:
+def render_sidebar(
+    cat_cols: list[str], prem_cols: list[str]
+) -> tuple[list[str], list[str], str | None]:
     """Render sidebar controls and return user selections."""
 
     value_options = ["IncurLoss", "CumPaidLoss"]
@@ -34,25 +33,30 @@ def render_sidebar(cat_cols: list[str]) -> tuple[list[str], list[str]]:
         "Value columns", value_options, default=value_options
     )
     group_cols = st.sidebar.multiselect("Group triangles by", cat_cols)
-    return selected_values, group_cols
+    prem_col = None
+    if prem_cols:
+        prem_col = st.sidebar.selectbox("Premium column", prem_cols, index=0)
+    return selected_values, group_cols, prem_col
 
 
 def main() -> None:
     """Streamlit application entry point."""
 
     st.title("Claims Triangle")
-    df, cat_cols = process_data()
-    selected_values, group_cols = render_sidebar(cat_cols)
+    df, cat_cols, prem_cols = process_data()
+    selected_values, group_cols, prem_col = render_sidebar(cat_cols, prem_cols)
+
+    value_cols = selected_values + ([prem_col] if prem_col else [])
 
     utils = ReservingAppTriangle(
         df,
         origin="origin",
         development="development",
-        value_cols=selected_values,
+        value_cols=value_cols,
         group_cols=group_cols,
         cumulative=True,
     )
-    utils.fit_development_model()
+    utils.fit_development_model(prem_col=prem_col)
     triangles = utils.triangles
 
     # Restructure triangles so that each grouping combination renders its
@@ -68,6 +72,8 @@ def main() -> None:
         if group_title is not None:
             st.subheader(group_title)
         for val_col, tri in val_map.items():
+            if val_col == prem_col:
+                continue
             # When no grouping columns are supplied, the value column itself
             # should serve as the subheader.  Otherwise, display the value
             # column as a caption within the group section.

--- a/app.py
+++ b/app.py
@@ -56,7 +56,8 @@ def main() -> None:
         group_cols=group_cols,
         cumulative=True,
     )
-    utils.fit_development_model(prem_col=prem_col)
+    utils.fit_development_model()
+    utils.get_reserve_exhibit(prem_col=prem_col)
     triangles_dfs = utils.triangle_dfs
     triangles_ata_dfs = utils.triangle_ata_dfs
 
@@ -99,9 +100,9 @@ def main() -> None:
                 custom_aggrid(utils.cdf_exhibit[(group_title, val_col)])
             with reserve_tab:
                 st.markdown("**Reserve Exhibit**")
-                # custom_aggrid(
-                #     utils.reserve_exhibit[(group_title, val_col)], index_label="Year"
-                # )
+                custom_aggrid(
+                    utils.reserve_exhibit[(group_title, val_col)], index_label="Year"
+                )
         st.write("---")
 
 

--- a/app.py
+++ b/app.py
@@ -88,20 +88,20 @@ def main() -> None:
             with value_tab:
                 custom_aggrid(tri)
             with ata_tab:
-                custom_aggrid(tri.link_ratio.to_frame())
+                # custom_aggrid(tri.link_ratio.to_frame())
                 st.markdown("**LDFs**")
-                custom_aggrid(
-                    utils.ldf_exhibit[(group_title, val_col)],
-                )
+                # custom_aggrid(
+                #     utils.ldf_exhibit[(group_title, val_col)],
+                # )
                 st.markdown("**CDFs**")
-                custom_aggrid(
-                    utils.cdf_exhibit[(group_title, val_col)],
-                )
+                # custom_aggrid(
+                #     utils.cdf_exhibit[(group_title, val_col)],
+                # )
             with reserve_tab:
                 st.markdown("**Reserve Exhibit**")
-                custom_aggrid(
-                    utils.reserve_exhibit[(group_title, val_col)], index_label="Year"
-                )
+                # custom_aggrid(
+                #     utils.reserve_exhibit[(group_title, val_col)], index_label="Year"
+                # )
         st.write("---")
 
 

--- a/app.py
+++ b/app.py
@@ -57,51 +57,49 @@ def main() -> None:
         cumulative=True,
     )
     utils.fit_development_model(prem_col=prem_col)
-    triangles = utils.triangles
     triangles_dfs = utils.triangle_dfs
+    triangles_ata_dfs = utils.triangle_ata_dfs
 
     # Restructure triangles so that each grouping combination renders its
     # associated value column triangles together rather than as individual
-    # entries.  ``triangles`` is keyed by ``(group_title, value_col)``; group
-    # them by ``group_title`` first, then iterate the value columns within
-    # each group.
-    grouped: dict[str | None, dict[str, cl.Triangle]] = {}
-    for (group_title, val_col), tri in triangles_dfs.items():
-        grouped.setdefault(group_title, {})[val_col] = tri
+    # entries. ``triangles_dfs`` and ``triangles_ata_dfs`` are keyed by
+    # ``(group_title, value_col)``; group them by ``group_title`` first and
+    # attach both value and ATA DataFrames so they can be displayed together.
+    grouped: dict[str | None, dict[str, dict[str, pd.DataFrame]]] = {}
+    for key, tri_df in triangles_dfs.items():
+        group_title, val_col = key
+        grouped.setdefault(group_title, {}).setdefault(val_col, {})['values'] = tri_df
+    for key, ata_df in triangles_ata_dfs.items():
+        group_title, val_col = key
+        grouped.setdefault(group_title, {}).setdefault(val_col, {})['ata'] = ata_df
 
     for group_title, val_map in grouped.items():
         if group_title is not None:
             st.subheader(group_title)
-        for val_col, tri in val_map.items():
+        for val_col, tri_map in val_map.items():
             if val_col == prem_col:
                 continue
             # When no grouping columns are supplied, the value column itself
-            # should serve as the subheader.  Otherwise, display the value
+            # should serve as the subheader. Otherwise, display the value
             # column as a caption within the group section.
             if group_title is None:
                 st.subheader(val_col)
             else:
                 st.markdown(f"**{val_col}**")
-            value_tab, ata_tab, reserve_tab = st.tabs(
-                ["Values", "ATA", "Reserve Exhibit"]
-            )
+            value_tab, ata_tab, reserve_tab = st.tabs(["Values", "ATA", "Reserve Exhibit"])
             with value_tab:
-                custom_aggrid(tri)
+                custom_aggrid(tri_map.get('values', pd.DataFrame()))
             with ata_tab:
-                # custom_aggrid(tri.link_ratio.to_frame())
+                custom_aggrid(tri_map.get('ata', pd.DataFrame()))
                 st.markdown("**LDFs**")
-                # custom_aggrid(
-                #     utils.ldf_exhibit[(group_title, val_col)],
-                # )
+                custom_aggrid(utils.ldf_exhibit[(group_title, val_col)])
                 st.markdown("**CDFs**")
-                # custom_aggrid(
-                #     utils.cdf_exhibit[(group_title, val_col)],
-                # )
+                custom_aggrid(utils.cdf_exhibit[(group_title, val_col)])
             with reserve_tab:
                 st.markdown("**Reserve Exhibit**")
-                # custom_aggrid(
-                #     utils.reserve_exhibit[(group_title, val_col)], index_label="Year"
-                # )
+                custom_aggrid(
+                    utils.reserve_exhibit[(group_title, val_col)], index_label="Year"
+                )
         st.write("---")
 
 

--- a/app.py
+++ b/app.py
@@ -68,10 +68,10 @@ def main() -> None:
     grouped: dict[str | None, dict[str, dict[str, pd.DataFrame]]] = {}
     for key, tri_df in triangles_dfs.items():
         group_title, val_col = key
-        grouped.setdefault(group_title, {}).setdefault(val_col, {})['values'] = tri_df
+        grouped.setdefault(group_title, {}).setdefault(val_col, {})["values"] = tri_df
     for key, ata_df in triangles_ata_dfs.items():
         group_title, val_col = key
-        grouped.setdefault(group_title, {}).setdefault(val_col, {})['ata'] = ata_df
+        grouped.setdefault(group_title, {}).setdefault(val_col, {})["ata"] = ata_df
 
     for group_title, val_map in grouped.items():
         if group_title is not None:
@@ -86,20 +86,22 @@ def main() -> None:
                 st.subheader(val_col)
             else:
                 st.markdown(f"**{val_col}**")
-            value_tab, ata_tab, reserve_tab = st.tabs(["Values", "ATA", "Reserve Exhibit"])
+            value_tab, ata_tab, reserve_tab = st.tabs(
+                ["Values", "ATA", "Reserve Exhibit"]
+            )
             with value_tab:
-                custom_aggrid(tri_map.get('values', pd.DataFrame()))
+                custom_aggrid(tri_map.get("values", pd.DataFrame()))
             with ata_tab:
-                custom_aggrid(tri_map.get('ata', pd.DataFrame()))
+                custom_aggrid(tri_map.get("ata", pd.DataFrame()))
                 st.markdown("**LDFs**")
                 custom_aggrid(utils.ldf_exhibit[(group_title, val_col)])
                 st.markdown("**CDFs**")
                 custom_aggrid(utils.cdf_exhibit[(group_title, val_col)])
             with reserve_tab:
                 st.markdown("**Reserve Exhibit**")
-                custom_aggrid(
-                    utils.reserve_exhibit[(group_title, val_col)], index_label="Year"
-                )
+                # custom_aggrid(
+                #     utils.reserve_exhibit[(group_title, val_col)], index_label="Year"
+                # )
         st.write("---")
 
 

--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ def render_sidebar(
 
 def main() -> None:
     """Streamlit application entry point."""
-
+    st.set_page_config(layout="wide")
     st.title("Claims Triangle")
     df, cat_cols, prem_cols = process_data()
     selected_values, group_cols, prem_col = render_sidebar(cat_cols, prem_cols)
@@ -58,6 +58,7 @@ def main() -> None:
     )
     utils.fit_development_model(prem_col=prem_col)
     triangles = utils.triangles
+    triangles_dfs = utils.triangle_dfs
 
     # Restructure triangles so that each grouping combination renders its
     # associated value column triangles together rather than as individual
@@ -65,7 +66,7 @@ def main() -> None:
     # them by ``group_title`` first, then iterate the value columns within
     # each group.
     grouped: dict[str | None, dict[str, cl.Triangle]] = {}
-    for (group_title, val_col), tri in triangles.items():
+    for (group_title, val_col), tri in triangles_dfs.items():
         grouped.setdefault(group_title, {})[val_col] = tri
 
     for group_title, val_map in grouped.items():
@@ -85,14 +86,19 @@ def main() -> None:
                 ["Values", "ATA", "Reserve Exhibit"]
             )
             with value_tab:
-                custom_aggrid(tri.to_frame(), index_label="Year")
+                custom_aggrid(tri)
             with ata_tab:
-                custom_aggrid(tri.link_ratio.to_frame(), index_label="Year")
+                custom_aggrid(tri.link_ratio.to_frame())
                 st.markdown("**LDFs**")
-                custom_aggrid(utils.ldf_exhibit[(group_title, val_col)])
+                custom_aggrid(
+                    utils.ldf_exhibit[(group_title, val_col)],
+                )
                 st.markdown("**CDFs**")
-                custom_aggrid(utils.cdf_exhibit[(group_title, val_col)])
+                custom_aggrid(
+                    utils.cdf_exhibit[(group_title, val_col)],
+                )
             with reserve_tab:
+                st.markdown("**Reserve Exhibit**")
                 custom_aggrid(
                     utils.reserve_exhibit[(group_title, val_col)], index_label="Year"
                 )

--- a/app.py
+++ b/app.py
@@ -91,16 +91,16 @@ def main() -> None:
                 ["Values", "ATA", "Reserve Exhibit"]
             )
             with value_tab:
-                custom_aggrid(tri_map.get("values", pd.DataFrame()))
+                custom_st_dataframe(tri_map.get("values", pd.DataFrame()))
             with ata_tab:
-                custom_aggrid(tri_map.get("ata", pd.DataFrame()))
+                custom_st_dataframe(tri_map.get("ata", pd.DataFrame()))
                 st.markdown("**LDFs**")
-                custom_aggrid(utils.ldf_exhibit[(group_title, val_col)])
+                custom_st_dataframe(utils.ldf_exhibit[(group_title, val_col)])
                 st.markdown("**CDFs**")
-                custom_aggrid(utils.cdf_exhibit[(group_title, val_col)])
+                custom_st_dataframe(utils.cdf_exhibit[(group_title, val_col)])
             with reserve_tab:
                 st.markdown("**Reserve Exhibit**")
-                custom_aggrid(utils.reserve_exhibit[(group_title, val_col)])
+                custom_st_dataframe(utils.reserve_exhibit[(group_title, val_col)])
         st.write("---")
 
 

--- a/app.py
+++ b/app.py
@@ -100,9 +100,7 @@ def main() -> None:
                 custom_aggrid(utils.cdf_exhibit[(group_title, val_col)])
             with reserve_tab:
                 st.markdown("**Reserve Exhibit**")
-                custom_aggrid(
-                    utils.reserve_exhibit[(group_title, val_col)], index_label="Year"
-                )
+                custom_aggrid(utils.reserve_exhibit[(group_title, val_col)])
         st.write("---")
 
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -9,6 +9,7 @@ from pandas.api.types import (
     is_integer_dtype,
     is_string_dtype,
 )
+
 try:  # st_aggrid is optional
     from st_aggrid import AgGrid, GridOptionsBuilder, JsCode
 except Exception:  # pragma: no cover
@@ -137,7 +138,7 @@ def custom_st_dataframe(df: pd.DataFrame) -> None:
     column_config: dict[str, st.column_config.NumberColumn] = {}
     for col in numeric_cols:
         max_val = df[col].abs().max()
-        fmt = "%,.0f" if max_val > 999 else "%,.2f"
+        fmt = "localized" if max_val > 999 else "%.2f"
         column_config[col] = st.column_config.NumberColumn(format=fmt)
 
     st.dataframe(df, hide_index=True, column_config=column_config)

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -278,7 +278,7 @@ class ReservingAppTriangle:
                     self.triangle[val_col]
                 )
                 triangle_atas[(None, val_col)] = convert_triangle_to_df(
-                    sub_tri[val_col].link_ratio
+                    self.triangle[val_col].link_ratio
                 )
 
         return triangles, triangle_atas
@@ -348,15 +348,15 @@ class ReservingAppTriangle:
             dev_simp = cl.Development(average="simple").fit(tri)
 
             ldf_vol = dev_vol.ldf_.to_frame()
-            ldf_vol["Avg Method"] = ["Volume Weighted"]
+            ldf_vol.index = ["Volume Weighted"]
             ldf_simp = dev_simp.ldf_.to_frame()
-            ldf_simp["Avg Method"] = ["Simple Average"]
+            ldf_simp.index = ["Simple Average"]
             self.ldf_exhibit[key] = pd.concat([ldf_vol, ldf_simp])
 
             cdf_vol = dev_vol.cdf_.to_frame()
-            cdf_vol["Avg Method"] = ["Volume Weighted"]
+            cdf_vol.index = ["Volume Weighted"]
             cdf_simp = dev_simp.cdf_.to_frame()
-            cdf_simp["Avg Method"] = ["Simple Average"]
+            cdf_simp.index = ["Simple Average"]
             self.cdf_exhibit[key] = pd.concat([cdf_vol, cdf_simp])
 
     def fit_development_model(

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -411,16 +411,24 @@ class ReservingAppTriangle:
 
             if development_method.lower() == "chainladder":
                 pipe = cl.Pipeline([("chainladder", cl.Chainladder())]).fit(tri)
-                ultimate_df = pipe["chainladder"].ultimate_.to_frame()
+                ultimate_df = self.convert_triangle_to_df(
+                    triangle=pipe["chainladder"].ultimate_, index_name="Year"
+                )
                 if len(ultimate_df.columns) == 1:
-                    ultimate_df.columns = ["Ultimate"]
+                    ultimate_df.columns = ["Chainladder Ultimate"]
 
                 premium_df = None
                 if prem_col and (group_title, prem_col) in self.triangles:
-                    premium_df = self.triangles[
-                        (group_title, prem_col)
-                    ].latest_diagonal.to_frame(prem_col)
-                latest_df = tri.latest_diagonal.to_frame(val_col)
+                    premium_df = self.convert_triangle_to_df(
+                        triangle=self.triangles[
+                            (group_title, prem_col)
+                        ].latest_diagonal,
+                        index_name="Year",
+                    )
+                latest_df = self.convert_triangle_to_df(
+                    tri.latest_diagonal[val_col],
+                    index_name="Year",
+                )
                 frames = [
                     f for f in [premium_df, latest_df, ultimate_df] if f is not None
                 ]

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -354,17 +354,21 @@ class ReservingAppTriangle:
             ldf_vol_df = self.convert_triangle_to_df(
                 dev_vol.ldf_, index_name="Avg Method"
             )
+            ldf_vol_df["Avg Method"] = "Volume Weighted"
             ldf_simp_df = self.convert_triangle_to_df(
                 dev_simp.ldf_, index_name="Avg Method"
             )
+            ldf_simp_df["Avg Method"] = "Simple Average"
             self.ldf_exhibit[key] = pd.concat([ldf_vol_df, ldf_simp_df])
 
             cdf_vol_df = self.convert_triangle_to_df(
                 dev_vol.cdf_, index_name="Avg Method"
             )
+            cdf_vol_df["Avg Method"] = "Volume Weighted"
             cdf_simp_df = self.convert_triangle_to_df(
                 dev_simp.cdf_, index_name="Avg Method"
             )
+            cdf_simp_df["Avg Method"] = "Simple Average"
             self.cdf_exhibit[key] = pd.concat([cdf_vol_df, cdf_simp_df])
 
     def fit_development_model(

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -9,7 +9,10 @@ from pandas.api.types import (
     is_integer_dtype,
     is_string_dtype,
 )
-from st_aggrid import AgGrid, GridOptionsBuilder, JsCode
+try:  # st_aggrid is optional
+    from st_aggrid import AgGrid, GridOptionsBuilder, JsCode
+except Exception:  # pragma: no cover
+    AgGrid = GridOptionsBuilder = JsCode = None
 
 
 def _coerce_year_column(df: pd.DataFrame, colname: str = "Year") -> pd.DataFrame:
@@ -42,66 +45,25 @@ def _coerce_year_column(df: pd.DataFrame, colname: str = "Year") -> pd.DataFrame
     return df
 
 
-def _json_safe(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    AgGrid sends data as JSON; JSON can't contain NaN/Infinity/<NA>.
-    Convert all missing to None and avoid NumPy scalars that serialize to NaN.
-    """
-    df = df.copy()
-    # Convert pandas NA/NaN to None
-    df = df.where(df.notna(), None)
-    # Make sure nullable integers don’t re-emit NaN; cast each column to Python objects
-    for c in df.columns:
-        if pd.api.types.is_integer_dtype(df[c]) and str(df[c].dtype).startswith("Int"):
-            df[c] = df[c].astype(object)  # keeps None for missing
-    return df
-
-
 def custom_aggrid(df: pd.DataFrame) -> dict:
     """Display ``df`` using AG Grid with numeric formatting.
 
-    The index is rendered as standard columns so that it appears in the grid
-    output.  All column labels are coerced to strings to avoid JavaScript
-    errors when numeric column names are encountered.
-
-    Numeric columns are formatted depending on whether their absolute maximum
-    value exceeds 999. Values greater than this threshold are shown with a
-    thousands separator and no decimals. Otherwise values are displayed with
-    two decimal places. Sorting remains based on the underlying numeric value
-    via ``valueFormatter`` JavaScript functions.
-
-    Parameters
-    ----------
-    df:
-        DataFrame to render.
-    index_label:
-        Optional name to use for the index column once rendered.  When
-        provided, this replaces the existing index name after reset.
-
-    Returns
-    -------
-    dict
-        Response returned by :func:`st_aggrid.AgGrid`.
+    If ``st_aggrid`` is unavailable the data is rendered using
+    :func:`custom_st_dataframe` to avoid runtime errors.
     """
 
-    # Display the index as regular columns and ensure all column labels are
-    # strings so that AG Grid's internal string operations do not fail on
-    # numeric names.
+    if GridOptionsBuilder is None:
+        custom_st_dataframe(df)
+        return {}
+
     index_levels = df.index.nlevels
     df.columns = df.columns.map(str)
 
-    df = _json_safe(df)
     gb = GridOptionsBuilder.from_dataframe(df)
-
-    # Make columns resizable & allow wrapping if needed
     gb.configure_default_column(resizable=True, wrapText=True, autoHeight=True)
-
-    # Let the grid grow to content height and avoid horizontal scroll
     gb.configure_grid_options(domLayout="autoHeight", suppressHorizontalScroll=True)
 
     numeric_cols = df.select_dtypes(include="number").columns
-    # Exclude index columns from numeric formatting to preserve values like
-    # "1990" without thousands separators.
     index_cols = df.columns[:index_levels]
     numeric_cols = [col for col in numeric_cols if col not in index_cols]
     for col in numeric_cols:
@@ -119,15 +81,12 @@ def custom_aggrid(df: pd.DataFrame) -> dict:
         gb.configure_column(col, type=["numericColumn"], valueFormatter=formatter)
 
     grid_options = gb.build()
-    # Autosize to content, then fit to container, and keep responsive
     grid_options["onFirstDataRendered"] = JsCode(
         """
         function(params) {
           let allColumnIds = [];
           params.columnApi.getAllColumns().forEach(c => allColumnIds.push(c.getId()));
-          // 1) Measure real content widths
           params.columnApi.autoSizeColumns(allColumnIds, false);
-          // 2) Then fill the remaining viewport neatly
           params.api.sizeColumnsToFit();
         }
     """
@@ -139,8 +98,33 @@ def custom_aggrid(df: pd.DataFrame) -> dict:
         }
     """
     )
-    st.dataframe(df, hide_index=True)
-    # return AgGrid(df, gridOptions=grid_options, allow_unsafe_jscode=True)
+    return AgGrid(df, gridOptions=grid_options, allow_unsafe_jscode=True)
+
+
+def custom_st_dataframe(df: pd.DataFrame) -> None:
+    """Display ``df`` with numeric formatting via ``st.dataframe``.
+
+    Numeric columns are formatted based on their absolute maximum values. When
+    the maximum exceeds ``999`` they are rendered with a thousands separator and
+    no decimals; otherwise two decimal places are shown.  Sorting remains
+    numeric because the underlying column dtypes are preserved and formatting is
+    handled through ``column_config``.
+    """
+
+    index_levels = df.index.nlevels
+    df.columns = df.columns.map(str)
+
+    numeric_cols = df.select_dtypes(include="number").columns
+    index_cols = df.columns[:index_levels]
+    numeric_cols = [c for c in numeric_cols if c not in index_cols]
+
+    column_config: dict[str, st.column_config.NumberColumn] = {}
+    for col in numeric_cols:
+        max_val = df[col].abs().max()
+        fmt = "%,.0f" if max_val > 999 else "%,.2f"
+        column_config[col] = st.column_config.NumberColumn(format=fmt)
+
+    st.dataframe(df, hide_index=True, column_config=column_config)
 
 
 class ReservingAppTriangle:

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -56,6 +56,27 @@ def _json_safe(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
+def convert_triangle_to_df(triangle: cl.Triangle) -> pd.DataFrame:
+    """Convert a ``chainladder.Triangle`` to a DataFrame with a ``Year`` column.
+
+    Parameters
+    ----------
+    triangle:
+        Single column ``chainladder.Triangle`` to convert.
+
+    Returns
+    -------
+    pd.DataFrame
+        ``triangle`` converted to a DataFrame with the index reset, the first
+        column renamed to ``Year`` and coerced to an annual ``PeriodIndex``.
+    """
+
+    df = triangle.to_frame().reset_index()
+    df.rename(columns={df.columns[0]: "Year"}, inplace=True)
+    df["Year"] = pd.PeriodIndex(df["Year"], freq="Y")
+    return df
+
+
 def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
     """Display ``df`` using AG Grid with numeric formatting.
 
@@ -243,27 +264,13 @@ class ReservingAppTriangle:
                     f"{col}={val}" for col, val in zip(group_cols, row)
                 )
                 for val_col in value_cols:
-                    triangles[(group_title, val_col)] = (
-                        sub_tri[val_col].to_frame().reset_index()
-                    )
-                    triangles[(group_title, val_col)].rename(
-                        columns={triangles[(group_title, val_col)].columns[0]: "Year"},
-                        inplace=True,
-                    )
-                    triangles[(group_title, val_col)]["Year"] = pd.PeriodIndex(
-                        triangles[(group_title, val_col)]["Year"], freq="Y"
+                    triangles[(group_title, val_col)] = convert_triangle_to_df(
+                        sub_tri[val_col]
                     )
         else:
             for val_col in value_cols:
-                triangles[(None, val_col)] = (
-                    self.triangle[val_col].to_frame().reset_index()
-                )
-                triangles[(None, val_col)].rename(
-                    columns={triangles[(None, val_col)].columns[0]: "Year"},
-                    inplace=True,
-                )
-                triangles[(None, val_col)]["Year"] = pd.PeriodIndex(
-                    triangles[(None, val_col)]["Year"], freq="Y"
+                triangles[(None, val_col)] = convert_triangle_to_df(
+                    self.triangle[val_col]
                 )
 
         return triangles

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -193,7 +193,7 @@ class ReservingAppTriangle:
         )
 
         # Split into DataFrame and Triangle representations for each subgroup
-        self.triangle_dfs = self.extract_triangle_dfs()
+        self.triangle_dfs, self.triangle_ata_dfs = self.extract_triangle_dfs()
 
         # Compute development factor exhibits for each subgroup
         self.get_dev_factor_exhibit()
@@ -254,6 +254,8 @@ class ReservingAppTriangle:
         value_cols = list(self.triangle.columns)
 
         triangles: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
+        triangle_atas: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
+        group_title = None
         if group_cols:
             unique_groups = index_df[group_cols].drop_duplicates()
             for row in unique_groups.itertuples(index=False, name=None):
@@ -267,13 +269,19 @@ class ReservingAppTriangle:
                     triangles[(group_title, val_col)] = convert_triangle_to_df(
                         sub_tri[val_col]
                     )
+                    triangle_atas[(group_title, val_col)] = convert_triangle_to_df(
+                        sub_tri[val_col].link_ratio
+                    )
         else:
             for val_col in value_cols:
                 triangles[(None, val_col)] = convert_triangle_to_df(
                     self.triangle[val_col]
                 )
+                triangle_atas[(None, val_col)] = convert_triangle_to_df(
+                    sub_tri[val_col].link_ratio
+                )
 
-        return triangles
+        return triangles, triangle_atas
 
     def extract_triangles(
         self,

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -232,6 +232,35 @@ class ReservingAppTriangle:
             df[index_name] = pd.PeriodIndex(df[index_name], freq="Y")
         return df
 
+    def convert_and_label_triangle(
+        self,
+        triangle: cl.Triangle,
+        value_name: str,
+        index_name: str = "Year",
+    ) -> pd.DataFrame:
+        """Convert ``triangle`` to a two-column DataFrame with a named value.
+
+        Parameters
+        ----------
+        triangle:
+            Single column ``chainladder.Triangle`` to convert.
+        value_name:
+            Name to assign to the value column.
+        index_name:
+            Name to assign to the first column after the index is reset.
+
+        Returns
+        -------
+        pd.DataFrame
+            DataFrame containing the index column and the renamed value column.
+        """
+
+        df = self.convert_triangle_to_df(triangle=triangle, index_name=index_name)
+        if df.shape[1] >= 2:
+            df = df.iloc[:, :2]
+            df.rename(columns={df.columns[1]: value_name}, inplace=True)
+        return df
+
     def extract_triangle_dfs(
         self,
     ) -> Dict[Tuple[Optional[str], str], pd.DataFrame]:
@@ -434,8 +463,10 @@ class ReservingAppTriangle:
         if prem_col:
             for (group_title, val_col), tri in self.triangles.items():
                 if val_col == prem_col:
-                    premium_dfs[group_title] = self.convert_triangle_to_df(
-                        triangle=tri.latest_diagonal, index_name="Year"
+                    premium_dfs[group_title] = self.convert_and_label_triangle(
+                        triangle=tri.latest_diagonal,
+                        value_name=prem_col,
+                        index_name="Year",
                     )
 
         self.reserve_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
@@ -447,14 +478,16 @@ class ReservingAppTriangle:
 
             tri = self.triangles[key]
 
-            ultimate_df = self.convert_triangle_to_df(
-                triangle=model["chainladder"].ultimate_, index_name="Year"
+            ultimate_df = self.convert_and_label_triangle(
+                triangle=model["chainladder"].ultimate_,
+                value_name="Chainladder Ultimate",
+                index_name="Year",
             )
-            if len(ultimate_df.columns) == 1:
-                ultimate_df.columns = ["Chainladder Ultimate"]
 
-            latest_df = self.convert_triangle_to_df(
-                triangle=tri.latest_diagonal, index_name="Year"
+            latest_df = self.convert_and_label_triangle(
+                triangle=tri.latest_diagonal,
+                value_name=val_col,
+                index_name="Year",
             )
 
             premium_df = premium_dfs.get(group_title)

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -330,13 +330,26 @@ class ReservingAppTriangle:
             cdf_simp.index = ["Simple Average"]
             self.cdf_exhibit[key] = pd.concat([cdf_vol, cdf_simp])
 
-    def fit_development_model(self, development_method: str = "chainladder") -> None:
+    def fit_development_model(
+        self, development_method: str = "chainladder", prem_col: Optional[str] = None
+    ) -> None:
         """Fit a development model and store resulting exhibits.
 
         Currently supports only the deterministic Chainladder method.  For each
         triangle derived from :meth:`extract_triangles`, a ``Pipeline`` is used
         to fit the selected development model and the ultimate losses by origin
         year are captured on the ``reserve_exhibit`` attribute.
+
+        Parameters
+        ----------
+        development_method:
+            Reserving technique to apply.  Only ``"chainladder"`` is supported
+            at present.
+        prem_col:
+            Optional premium column included in ``value_cols``.  When provided,
+            the premium's latest diagonal is added as the second column of the
+            reserve exhibit and separate exhibits for the premium column are
+            omitted.
         """
 
         if not hasattr(self, "triangles"):
@@ -345,12 +358,25 @@ class ReservingAppTriangle:
         self.reserve_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
 
         for key, tri in self.triangles.items():
+            group_title, val_col = key
+            if val_col == prem_col:
+                continue
+
             if development_method.lower() == "chainladder":
                 pipe = cl.Pipeline([("chainladder", cl.Chainladder())]).fit(tri)
                 ultimate_df = pipe["chainladder"].ultimate_.to_frame()
                 if len(ultimate_df.columns) == 1:
                     ultimate_df.columns = ["Ultimate"]
-                self.reserve_exhibit[key] = ultimate_df
+
+                premium_df = None
+                if prem_col and (group_title, prem_col) in self.triangles:
+                    premium_df = (
+                        self.triangles[(group_title, prem_col)]
+                        .latest_diagonal.to_frame(prem_col)
+                    )
+                latest_df = tri.latest_diagonal.to_frame(val_col)
+                frames = [f for f in [premium_df, latest_df, ultimate_df] if f is not None]
+                self.reserve_exhibit[key] = pd.concat(frames, axis=1)
             else:
                 raise ValueError(
                     f"Unsupported development method: {development_method}"

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -105,7 +105,6 @@ def custom_aggrid(df: pd.DataFrame) -> dict:
     numeric_cols = [col for col in numeric_cols if col not in index_cols]
     for col in numeric_cols:
         max_val = df[col].abs().max()
-        st.write(max_val)
         if max_val > 999:
             formatter = JsCode(
                 "function(params) {return Number(params.value).toLocaleString('en-US', "
@@ -461,6 +460,10 @@ class ReservingAppTriangle:
             premium_df = premium_dfs.get(group_title)
 
             frames = [f for f in [premium_df, latest_df, ultimate_df] if f is not None]
+            st.write(premium_df, hide_index=True)
+            st.write(latest_df, hide_index=True)
+            st.write(ultimate_df, hide_index=True)
             self.reserve_exhibit[key] = pd.concat(frames, axis=1)
+            st.write(self.reserve_exhibit[key], hide_index=True)
 
         return self.reserve_exhibit

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -346,22 +346,26 @@ class ReservingAppTriangle:
 
         for key, tri in self.triangles.items():
             self.triangle_ata_dfs[key] = self.convert_triangle_to_df(
-                tri.ata, index_name="Development"
+                tri.age_to_age, index_name="Year"
             )
             dev_vol = cl.Development().fit(tri)
             dev_simp = cl.Development(average="simple").fit(tri)
 
-            ldf_vol = dev_vol.ldf_.to_frame()
-            ldf_vol.index = ["Volume Weighted"]
-            ldf_simp = dev_simp.ldf_.to_frame()
-            ldf_simp.index = ["Simple Average"]
-            self.ldf_exhibit[key] = pd.concat([ldf_vol, ldf_simp])
+            ldf_vol_df = self.convert_triangle_to_df(
+                dev_vol.ldf_, index_name="Avg Method"
+            )
+            ldf_simp_df = self.convert_triangle_to_df(
+                dev_simp.ldf_, index_name="Avg Method"
+            )
+            self.ldf_exhibit[key] = pd.concat([ldf_vol_df, ldf_simp_df])
 
-            cdf_vol = dev_vol.cdf_.to_frame()
-            cdf_vol.index = ["Volume Weighted"]
-            cdf_simp = dev_simp.cdf_.to_frame()
-            cdf_simp.index = ["Simple Average"]
-            self.cdf_exhibit[key] = pd.concat([cdf_vol, cdf_simp])
+            cdf_vol_df = self.convert_triangle_to_df(
+                dev_vol.cdf_, index_name="Avg Method"
+            )
+            cdf_simp_df = self.convert_triangle_to_df(
+                dev_simp.cdf_, index_name="Avg Method"
+            )
+            self.cdf_exhibit[key] = pd.concat([cdf_vol_df, cdf_simp_df])
 
     def fit_development_model(
         self, development_method: str = "chainladder", prem_col: Optional[str] = None

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -112,11 +112,16 @@ def custom_st_dataframe(df: pd.DataFrame) -> None:
     """
 
     index_levels = df.index.nlevels
+    df = df.copy()
     df.columns = df.columns.map(str)
 
     numeric_cols = df.select_dtypes(include="number").columns
     index_cols = df.columns[:index_levels]
     numeric_cols = [c for c in numeric_cols if c not in index_cols]
+
+    # Ensure numeric columns are float so missing values (None/pd.NA) don't
+    # trigger formatting errors when passed through ``st.column_config``.
+    df[numeric_cols] = df[numeric_cols].apply(pd.to_numeric, errors="coerce")
 
     column_config: dict[str, st.column_config.NumberColumn] = {}
     for col in numeric_cols:

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -56,7 +56,7 @@ def _json_safe(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
+def custom_aggrid(df: pd.DataFrame) -> dict:
     """Display ``df`` using AG Grid with numeric formatting.
 
     The index is rendered as standard columns so that it appears in the grid
@@ -105,6 +105,7 @@ def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
     numeric_cols = [col for col in numeric_cols if col not in index_cols]
     for col in numeric_cols:
         max_val = df[col].abs().max()
+        st.write(max_val)
         if max_val > 999:
             formatter = JsCode(
                 "function(params) {return Number(params.value).toLocaleString('en-US', "

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -1,5 +1,6 @@
 import chainladder as cl
 import pandas as pd
+from functools import reduce
 from typing import Dict, List, Optional, Tuple
 import streamlit as st
 from pandas.api.types import (
@@ -496,7 +497,10 @@ class ReservingAppTriangle:
             st.write(premium_df, hide_index=True)
             st.write(latest_df, hide_index=True)
             st.write(ultimate_df, hide_index=True)
-            self.reserve_exhibit[key] = pd.concat(frames, axis=1)
+            self.reserve_exhibit[key] = reduce(
+                lambda left, right: pd.merge(left, right, on="Year", how="outer"),
+                frames,
+            )
             st.write(self.reserve_exhibit[key], hide_index=True)
 
         return self.reserve_exhibit

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -112,11 +112,23 @@ def custom_st_dataframe(df: pd.DataFrame) -> None:
     """
 
     index_levels = df.index.nlevels
+    df = df.copy()
     df.columns = df.columns.map(str)
 
-    numeric_cols = df.select_dtypes(include="number").columns
-    index_cols = df.columns[:index_levels]
-    numeric_cols = [c for c in numeric_cols if c not in index_cols]
+    index_cols = list(df.columns[:index_levels])
+    numeric_cols: list[str] = []
+
+    # Coerce any column that can be interpreted numerically (even if its dtype
+    # is ``object`` due to ``None``/``pd.NA``) so ``st.column_config`` receives
+    # clean ``float`` data. Columns that are entirely non-numeric remain
+    # untouched and won't receive a numeric formatter.
+    for col in df.columns:
+        if col in index_cols:
+            continue
+        converted = pd.to_numeric(df[col], errors="coerce")
+        if converted.notna().any():
+            df[col] = converted
+            numeric_cols.append(col)
 
     column_config: dict[str, st.column_config.NumberColumn] = {}
     for col in numeric_cols:

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -56,27 +56,6 @@ def _json_safe(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-def convert_triangle_to_df(triangle: cl.Triangle) -> pd.DataFrame:
-    """Convert a ``chainladder.Triangle`` to a DataFrame with a ``Year`` column.
-
-    Parameters
-    ----------
-    triangle:
-        Single column ``chainladder.Triangle`` to convert.
-
-    Returns
-    -------
-    pd.DataFrame
-        ``triangle`` converted to a DataFrame with the index reset, the first
-        column renamed to ``Year`` and coerced to an annual ``PeriodIndex``.
-    """
-
-    df = triangle.to_frame().reset_index()
-    df.rename(columns={df.columns[0]: "Year"}, inplace=True)
-    df["Year"] = pd.PeriodIndex(df["Year"], freq="Y")
-    return df
-
-
 def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
     """Display ``df`` using AG Grid with numeric formatting.
 
@@ -192,8 +171,9 @@ class ReservingAppTriangle:
             cumulative=cumulative,
         )
 
-        # Split into DataFrame and Triangle representations for each subgroup
-        self.triangle_dfs, self.triangle_ata_dfs = self.extract_triangle_dfs()
+        # Split into DataFrame representations for each subgroup
+        self.triangle_dfs = self.extract_triangle_dfs()
+        self.triangle_ata_dfs: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
 
         # Compute development factor exhibits for each subgroup
         self.get_dev_factor_exhibit()
@@ -225,6 +205,33 @@ class ReservingAppTriangle:
         )
         return self.triangle
 
+    def convert_triangle_to_df(
+        self, triangle: cl.Triangle, index_name: str = "Year"
+    ) -> pd.DataFrame:
+        """Convert a ``chainladder.Triangle`` to a DataFrame with a named index column.
+
+        Parameters
+        ----------
+        triangle:
+            Single column ``chainladder.Triangle`` to convert.
+        index_name:
+            Name to assign to the first column after the index is reset. If
+            ``index_name`` is ``"Year"`` (case insensitive) the column is
+            coerced to an annual ``PeriodIndex``.
+
+        Returns
+        -------
+        pd.DataFrame
+            ``triangle`` converted to a DataFrame with the index reset and
+            renamed column.
+        """
+
+        df = triangle.to_frame().reset_index()
+        df.rename(columns={df.columns[0]: index_name}, inplace=True)
+        if index_name.lower() == "year":
+            df[index_name] = pd.PeriodIndex(df[index_name], freq="Y")
+        return df
+
     def extract_triangle_dfs(
         self,
     ) -> Dict[Tuple[Optional[str], str], pd.DataFrame]:
@@ -254,7 +261,6 @@ class ReservingAppTriangle:
         value_cols = list(self.triangle.columns)
 
         triangles: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
-        triangle_atas: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
         group_title = None
         if group_cols:
             unique_groups = index_df[group_cols].drop_duplicates()
@@ -266,22 +272,16 @@ class ReservingAppTriangle:
                     f"{col}={val}" for col, val in zip(group_cols, row)
                 )
                 for val_col in value_cols:
-                    triangles[(group_title, val_col)] = convert_triangle_to_df(
-                        sub_tri[val_col]
-                    )
-                    triangle_atas[(group_title, val_col)] = convert_triangle_to_df(
-                        sub_tri[val_col].link_ratio
+                    triangles[(group_title, val_col)] = self.convert_triangle_to_df(
+                        sub_tri[val_col], index_name="Year"
                     )
         else:
             for val_col in value_cols:
-                triangles[(None, val_col)] = convert_triangle_to_df(
-                    self.triangle[val_col]
-                )
-                triangle_atas[(None, val_col)] = convert_triangle_to_df(
-                    self.triangle[val_col].link_ratio
+                triangles[(None, val_col)] = self.convert_triangle_to_df(
+                    self.triangle[val_col], index_name="Year"
                 )
 
-        return triangles, triangle_atas
+        return triangles
 
     def extract_triangles(
         self,
@@ -340,10 +340,14 @@ class ReservingAppTriangle:
             raise ValueError("No triangle available. Call create_triangle first.")
 
         self.triangles = self.extract_triangles()
+        self.triangle_ata_dfs: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
         self.ldf_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
         self.cdf_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
 
         for key, tri in self.triangles.items():
+            self.triangle_ata_dfs[key] = self.convert_triangle_to_df(
+                tri.ata, index_name="Development"
+            )
             dev_vol = cl.Development().fit(tri)
             dev_simp = cl.Development(average="simple").fit(tri)
 

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -378,62 +378,88 @@ class ReservingAppTriangle:
             self.cdf_exhibit[key] = pd.concat(cdf_dfs)
 
     def fit_development_model(
-        self, development_method: str = "chainladder", prem_col: Optional[str] = None
-    ) -> None:
-        """Fit a development model and store resulting exhibits.
-
-        Currently supports only the deterministic Chainladder method.  For each
-        triangle derived from :meth:`extract_triangles`, a ``Pipeline`` is used
-        to fit the selected development model and the ultimate losses by origin
-        year are captured on the ``reserve_exhibit`` attribute.
+        self, development_method: str = "chainladder"
+    ) -> Dict[Tuple[Optional[str], str], cl.Pipeline]:
+        """Fit a development model to each triangle and return the results.
 
         Parameters
         ----------
         development_method:
             Reserving technique to apply.  Only ``"chainladder"`` is supported
             at present.
-        prem_col:
-            Optional premium column included in ``value_cols``.  When provided,
-            the premium's latest diagonal is added as the second column of the
-            reserve exhibit and separate exhibits for the premium column are
-            omitted.
+
+        Returns
+        -------
+        Dict[Tuple[str | None, str], ``cl.Pipeline``]
+            Mapping of ``(group_title, value_col)`` to the fitted model
+            pipelines.
         """
 
         if not hasattr(self, "triangles"):
             self.triangles = self.extract_triangles()
 
-        self.reserve_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
+        self.fitted_models: Dict[Tuple[Optional[str], str], cl.Pipeline] = {}
 
         for key, tri in self.triangles.items():
-            group_title, val_col = key
-            if val_col == prem_col:
-                continue
-
             if development_method.lower() == "chainladder":
                 pipe = cl.Pipeline([("chainladder", cl.Chainladder())]).fit(tri)
-                ultimate_df = self.convert_triangle_to_df(
-                    triangle=pipe["chainladder"].ultimate_, index_name="Year"
-                )
-                if len(ultimate_df.columns) == 1:
-                    ultimate_df.columns = ["Chainladder Ultimate"]
-
-                premium_df = None
-                if prem_col and (group_title, prem_col) in self.triangles:
-                    premium_df = self.convert_triangle_to_df(
-                        triangle=self.triangles[
-                            (group_title, prem_col)
-                        ].latest_diagonal,
-                        index_name="Year",
-                    )
-                latest_df = self.convert_triangle_to_df(
-                    tri.latest_diagonal[val_col],
-                    index_name="Year",
-                )
-                frames = [
-                    f for f in [premium_df, latest_df, ultimate_df] if f is not None
-                ]
-                self.reserve_exhibit[key] = pd.concat(frames, axis=1)
+                self.fitted_models[key] = pipe
             else:
                 raise ValueError(
                     f"Unsupported development method: {development_method}"
                 )
+
+        return self.fitted_models
+
+    def get_reserve_exhibit(
+        self, prem_col: Optional[str] = None
+    ) -> Dict[Tuple[Optional[str], str], pd.DataFrame]:
+        """Return reserve exhibits using previously fitted development models.
+
+        Parameters
+        ----------
+        prem_col:
+            Optional premium column included in ``value_cols``.  When provided,
+            the premium's latest diagonal is added as the first column of the
+            reserve exhibit and separate exhibits for the premium column are
+            omitted.
+        """
+
+        if not hasattr(self, "fitted_models"):
+            raise ValueError(
+                "No fitted models available. Call fit_development_model first."
+            )
+
+        premium_dfs: Dict[Optional[str], pd.DataFrame] = {}
+        if prem_col:
+            for (group_title, val_col), tri in self.triangles.items():
+                if val_col == prem_col:
+                    premium_dfs[group_title] = self.convert_triangle_to_df(
+                        triangle=tri.latest_diagonal, index_name="Year"
+                    )
+
+        self.reserve_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
+
+        for key, model in self.fitted_models.items():
+            group_title, val_col = key
+            if val_col == prem_col:
+                continue
+
+            tri = self.triangles[key]
+
+            ultimate_df = self.convert_triangle_to_df(
+                triangle=model["chainladder"].ultimate_, index_name="Year"
+            )
+            if len(ultimate_df.columns) == 1:
+                ultimate_df.columns = ["Chainladder Ultimate"]
+
+            latest_df = self.convert_triangle_to_df(
+                triangle=tri.latest_diagonal, index_name="Year"
+            )
+
+            premium_df = premium_dfs.get(group_title)
+
+            frames = [f for f in [premium_df, latest_df, ultimate_df] if f is not None]
+            self.reserve_exhibit[key] = pd.concat(frames, axis=1)
+
+        return self.reserve_exhibit

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -176,7 +176,7 @@ class ReservingAppTriangle:
         self.triangle_ata_dfs: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
 
         # Compute development factor exhibits for each subgroup
-        self.get_dev_factor_exhibit()
+        self.get_dev_factor_exhibit(methods=["volume", "simple"])
 
     def create_triangle(
         self,
@@ -325,51 +325,57 @@ class ReservingAppTriangle:
                 triangles[(None, val_col)] = self.triangle[val_col]
         return triangles
 
-    def get_dev_factor_exhibit(self) -> None:
+    def get_dev_factor_exhibit(self, methods: Optional[List[str]] = None) -> None:
         """Generate LDF and CDF exhibits for each subgroup.
 
-        This method fits both volume weighted and simple average development
-        models to every triangle produced by :meth:`extract_triangles`.  The
-        resulting LDF and CDF tables are stored on ``ldf_exhibit`` and
-        ``cdf_exhibit`` dictionaries keyed by ``(group_title, value_col)``.
-        The underlying ``chainladder.Triangle`` objects are also stored on the
-        ``triangles`` attribute for easy access when rendering link ratios.
+        This method fits development models using the averaging methods
+        provided in ``methods`` to every triangle produced by
+        :meth:`extract_triangles`. The resulting LDF and CDF tables are stored
+        on ``ldf_exhibit`` and ``cdf_exhibit`` dictionaries keyed by
+        ``(group_title, value_col)``. The underlying ``chainladder.Triangle``
+        objects are also stored on the ``triangles`` attribute for easy access
+        when rendering link ratios.
+
+        Parameters
+        ----------
+        methods:
+            List of development averaging methods to apply. Defaults to
+            ``["volume", "simple"]``.
         """
 
         if self.triangle is None:
             raise ValueError("No triangle available. Call create_triangle first.")
+
+        methods = methods or ["volume", "simple"]
 
         self.triangles = self.extract_triangles()
         self.triangle_ata_dfs: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
         self.ldf_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
         self.cdf_exhibit: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
 
+        labels = {"volume": "Volume Weighted", "simple": "Simple Average"}
+
         for key, tri in self.triangles.items():
             self.triangle_ata_dfs[key] = self.convert_triangle_to_df(
                 tri.age_to_age, index_name="Year"
             )
-            dev_vol = cl.Development().fit(tri)
-            dev_simp = cl.Development(average="simple").fit(tri)
-
-            ldf_vol_df = self.convert_triangle_to_df(
-                dev_vol.ldf_, index_name="Avg Method"
-            )
-            ldf_vol_df["Avg Method"] = "Volume Weighted"
-            ldf_simp_df = self.convert_triangle_to_df(
-                dev_simp.ldf_, index_name="Avg Method"
-            )
-            ldf_simp_df["Avg Method"] = "Simple Average"
-            self.ldf_exhibit[key] = pd.concat([ldf_vol_df, ldf_simp_df])
-
-            cdf_vol_df = self.convert_triangle_to_df(
-                dev_vol.cdf_, index_name="Avg Method"
-            )
-            cdf_vol_df["Avg Method"] = "Volume Weighted"
-            cdf_simp_df = self.convert_triangle_to_df(
-                dev_simp.cdf_, index_name="Avg Method"
-            )
-            cdf_simp_df["Avg Method"] = "Simple Average"
-            self.cdf_exhibit[key] = pd.concat([cdf_vol_df, cdf_simp_df])
+            ldf_dfs: List[pd.DataFrame] = []
+            cdf_dfs: List[pd.DataFrame] = []
+            for method in methods:
+                dev = (
+                    cl.Development().fit(tri)
+                    if method == "volume"
+                    else cl.Development(average=method).fit(tri)
+                )
+                label = labels.get(method, method.title())
+                for attr, dfs in [("ldf_", ldf_dfs), ("cdf_", cdf_dfs)]:
+                    df = self.convert_triangle_to_df(
+                        getattr(dev, attr), index_name="Avg Method"
+                    )
+                    df["Avg Method"] = label
+                    dfs.append(df)
+            self.ldf_exhibit[key] = pd.concat(ldf_dfs)
+            self.cdf_exhibit[key] = pd.concat(cdf_dfs)
 
     def fit_development_model(
         self, development_method: str = "chainladder", prem_col: Optional[str] = None

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -89,12 +89,6 @@ def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
     index_levels = df.index.nlevels
     df.columns = df.columns.map(str)
 
-    if index_label == "Year":
-        df = df.reset_index()
-        df.rename(columns={df.columns[0]: index_label}, inplace=True)
-        df["Year"] = pd.PeriodIndex(df["Year"], freq="Y")
-
-    df = _coerce_year_column(df, index_label)
     df = _json_safe(df)
     gb = GridOptionsBuilder.from_dataframe(df)
 
@@ -144,7 +138,8 @@ def custom_aggrid(df: pd.DataFrame, index_label: Optional[str] = None) -> dict:
         }
     """
     )
-    return AgGrid(df, gridOptions=grid_options, allow_unsafe_jscode=True)
+    st.dataframe(df, hide_index=True)
+    # return AgGrid(df, gridOptions=grid_options, allow_unsafe_jscode=True)
 
 
 class ReservingAppTriangle:
@@ -248,10 +243,29 @@ class ReservingAppTriangle:
                     f"{col}={val}" for col, val in zip(group_cols, row)
                 )
                 for val_col in value_cols:
-                    triangles[(group_title, val_col)] = sub_tri[val_col].to_frame()
+                    triangles[(group_title, val_col)] = (
+                        sub_tri[val_col].to_frame().reset_index()
+                    )
+                    triangles[(group_title, val_col)].rename(
+                        columns={triangles[(group_title, val_col)].columns[0]: "Year"},
+                        inplace=True,
+                    )
+                    triangles[(group_title, val_col)]["Year"] = pd.PeriodIndex(
+                        triangles[(group_title, val_col)]["Year"], freq="Y"
+                    )
         else:
             for val_col in value_cols:
-                triangles[(None, val_col)] = self.triangle[val_col].to_frame()
+                triangles[(None, val_col)] = (
+                    self.triangle[val_col].to_frame().reset_index()
+                )
+                triangles[(None, val_col)].rename(
+                    columns={triangles[(None, val_col)].columns[0]: "Year"},
+                    inplace=True,
+                )
+                triangles[(None, val_col)]["Year"] = pd.PeriodIndex(
+                    triangles[(None, val_col)]["Year"], freq="Y"
+                )
+
         return triangles
 
     def extract_triangles(
@@ -319,15 +333,15 @@ class ReservingAppTriangle:
             dev_simp = cl.Development(average="simple").fit(tri)
 
             ldf_vol = dev_vol.ldf_.to_frame()
-            ldf_vol.index = ["Volume Weighted"]
+            ldf_vol["Avg Method"] = ["Volume Weighted"]
             ldf_simp = dev_simp.ldf_.to_frame()
-            ldf_simp.index = ["Simple Average"]
+            ldf_simp["Avg Method"] = ["Simple Average"]
             self.ldf_exhibit[key] = pd.concat([ldf_vol, ldf_simp])
 
             cdf_vol = dev_vol.cdf_.to_frame()
-            cdf_vol.index = ["Volume Weighted"]
+            cdf_vol["Avg Method"] = ["Volume Weighted"]
             cdf_simp = dev_simp.cdf_.to_frame()
-            cdf_simp.index = ["Simple Average"]
+            cdf_simp["Avg Method"] = ["Simple Average"]
             self.cdf_exhibit[key] = pd.concat([cdf_vol, cdf_simp])
 
     def fit_development_model(
@@ -370,12 +384,13 @@ class ReservingAppTriangle:
 
                 premium_df = None
                 if prem_col and (group_title, prem_col) in self.triangles:
-                    premium_df = (
-                        self.triangles[(group_title, prem_col)]
-                        .latest_diagonal.to_frame(prem_col)
-                    )
+                    premium_df = self.triangles[
+                        (group_title, prem_col)
+                    ].latest_diagonal.to_frame(prem_col)
                 latest_df = tri.latest_diagonal.to_frame(val_col)
-                frames = [f for f in [premium_df, latest_df, ultimate_df] if f is not None]
+                frames = [
+                    f for f in [premium_df, latest_df, ultimate_df] if f is not None
+                ]
                 self.reserve_exhibit[key] = pd.concat(frames, axis=1)
             else:
                 raise ValueError(

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -494,13 +494,9 @@ class ReservingAppTriangle:
             premium_df = premium_dfs.get(group_title)
 
             frames = [f for f in [premium_df, latest_df, ultimate_df] if f is not None]
-            st.write(premium_df, hide_index=True)
-            st.write(latest_df, hide_index=True)
-            st.write(ultimate_df, hide_index=True)
             self.reserve_exhibit[key] = reduce(
                 lambda left, right: pd.merge(left, right, on="Year", how="outer"),
                 frames,
             )
-            st.write(self.reserve_exhibit[key], hide_index=True)
 
         return self.reserve_exhibit


### PR DESCRIPTION
## Summary
- detect premium columns and expose selection in sidebar
- include premium in triangle data but omit from display
- enhance reserve exhibit with premium and latest loss values

## Testing
- `python -m py_compile app.py helper_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_6898d8dab0d08330964be756d98c8076