### PR TITLE
Handle missing values in Streamlit formatter

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -112,11 +112,16 @@ def custom_st_dataframe(df: pd.DataFrame) -> None:
     """
 
     index_levels = df.index.nlevels
+    df = df.copy()
     df.columns = df.columns.map(str)
 
     numeric_cols = df.select_dtypes(include="number").columns
     index_cols = df.columns[:index_levels]
     numeric_cols = [c for c in numeric_cols if c not in index_cols]
+
+    # Ensure numeric columns are float so missing values (None/pd.NA) don't
+    # trigger formatting errors when passed through ``st.column_config``.
+    df[numeric_cols] = df[numeric_cols].apply(pd.to_numeric, errors="coerce")
 
     column_config: dict[str, st.column_config.NumberColumn] = {}
     for col in numeric_cols:


### PR DESCRIPTION
## Summary
- avoid `st.dataframe` formatting errors when columns contain None/pd.NA values
- coerce numeric columns to floats before applying formatting

## Testing
- `python -m py_compile helper_functions.py`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689c3fc20f708330ad778ed207d0d80c