### PR TITLE
feat: allow editable selected ldf row

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,14 +107,17 @@ def main() -> None:
                 st.markdown("**LDFs**")
                 ldf_key = (group_title, val_col)
                 ldf_df = utils.ldf_exhibit[ldf_key]
-                # Disable editing for non-selected rows and Avg Method column
-                disabled = pd.DataFrame(True, index=ldf_df.index, columns=ldf_df.columns)
-                disabled.loc[ldf_df["Avg Method"] == "Selected", :] = False
-                disabled["Avg Method"] = True
+                # Enable editing only for the "Selected" row and keep the
+                # ``Avg Method`` column read-only so users can overwrite the
+                # LDF values.
+                row_disabled = ldf_df["Avg Method"] != "Selected"
                 edited_ldf_df = st.data_editor(
                     ldf_df,
                     key=f"ldf_{group_title}_{val_col}",
-                    disabled=disabled,
+                    disabled=row_disabled,
+                    column_config={
+                        "Avg Method": st.column_config.TextColumn(disabled=True)
+                    },
                 )
                 utils.ldf_exhibit[ldf_key] = edited_ldf_df
                 selected_row = (

--- a/app.py
+++ b/app.py
@@ -56,6 +56,10 @@ def main() -> None:
         group_cols=group_cols,
         cumulative=True,
     )
+    # Reapply any user-selected LDFs stored in session state before fitting models
+    for key, ldf_dict in st.session_state.get("custom_ldfs", {}).items():
+        utils.apply_selected_ldfs(key, pd.Series(ldf_dict))
+
     utils.fit_development_model(
         "chainladder", experiment_name="Basic Reserving Models"
     )
@@ -101,9 +105,27 @@ def main() -> None:
             with ata_tab:
                 custom_st_dataframe(tri_map.get("ata", pd.DataFrame()))
                 st.markdown("**LDFs**")
-                custom_st_dataframe(utils.ldf_exhibit[(group_title, val_col)])
+                ldf_key = (group_title, val_col)
+                ldf_df = utils.ldf_exhibit[ldf_key]
+                # Disable editing for non-selected rows and Avg Method column
+                disabled = pd.DataFrame(True, index=ldf_df.index, columns=ldf_df.columns)
+                disabled.loc[ldf_df["Avg Method"] == "Selected", :] = False
+                disabled["Avg Method"] = True
+                edited_ldf_df = st.data_editor(
+                    ldf_df,
+                    key=f"ldf_{group_title}_{val_col}",
+                    disabled=disabled,
+                )
+                utils.ldf_exhibit[ldf_key] = edited_ldf_df
+                selected_row = (
+                    edited_ldf_df[edited_ldf_df["Avg Method"] == "Selected"]
+                    .iloc[0]
+                    .drop("Avg Method")
+                )
+                st.session_state.setdefault("custom_ldfs", {})[ldf_key] = selected_row.to_dict()
+                utils.apply_selected_ldfs(ldf_key, selected_row)
                 st.markdown("**CDFs**")
-                custom_st_dataframe(utils.cdf_exhibit[(group_title, val_col)])
+                custom_st_dataframe(utils.cdf_exhibit[ldf_key])
             with reserve_tab:
                 st.markdown("**Reserve Exhibit**")
                 custom_st_dataframe(utils.reserve_exhibit[(group_title, val_col)])

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -185,6 +185,8 @@ class ReservingAppTriangle:
         # Split into DataFrame representations for each subgroup
         self.triangle_dfs = self.extract_triangle_dfs()
         self.triangle_ata_dfs: Dict[Tuple[Optional[str], str], pd.DataFrame] = {}
+        # Store user selected LDF patterns keyed by (group_title, value_col)
+        self.custom_ldfs: Dict[Tuple[Optional[str], str], Dict[int, float]] = {}
 
         # Compute development factor exhibits for each subgroup
         self.get_dev_factor_exhibit(methods=["volume", "simple"])
@@ -414,8 +416,69 @@ class ReservingAppTriangle:
                     )
                     df["Avg Method"] = label
                     dfs.append(df)
-            self.ldf_exhibit[key] = pd.concat(ldf_dfs)
-            self.cdf_exhibit[key] = pd.concat(cdf_dfs)
+            ldf_df = pd.concat(ldf_dfs)
+            cdf_df = pd.concat(cdf_dfs)
+
+            # Add an editable "Selected" row defaulting to Volume Weighted
+            vol_mask = ldf_df["Avg Method"] == "Volume Weighted"
+            if vol_mask.any():
+                selected_ldf = ldf_df.loc[vol_mask].copy()
+                selected_ldf["Avg Method"] = "Selected"
+                ldf_df = pd.concat([ldf_df, selected_ldf], ignore_index=True)
+
+                selected_cdf = cdf_df.loc[cdf_df["Avg Method"] == "Volume Weighted"].copy()
+                selected_cdf["Avg Method"] = "Selected"
+                cdf_df = pd.concat([cdf_df, selected_cdf], ignore_index=True)
+
+                # Initialize custom LDF patterns for this key based on volume values
+                factors = {
+                    int(col.split("-")[0]): selected_ldf.iloc[0][col]
+                    for col in selected_ldf.columns
+                    if col != "Avg Method"
+                }
+                self.custom_ldfs[key] = factors
+
+            self.ldf_exhibit[key] = ldf_df
+            self.cdf_exhibit[key] = cdf_df
+
+    def apply_selected_ldfs(
+        self,
+        key: Tuple[Optional[str], str],
+        ldf_series: pd.Series,
+    ) -> None:
+        """Update exhibits with user selected LDFs for ``key``.
+
+        Parameters
+        ----------
+        key:
+            Tuple of ``(group_title, value_col)`` identifying the triangle.
+        ldf_series:
+            Series of LDF values indexed by development period labels, e.g.
+            ``"12-24"``.
+        """
+
+        # Normalize the Series to float values and construct pattern dict
+        ldf_series = ldf_series.astype(float)
+        patterns = {int(col.split("-")[0]): val for col, val in ldf_series.items()}
+        self.custom_ldfs[key] = patterns
+
+        # Update LDF exhibit row
+        ldf_df = self.ldf_exhibit[key].copy()
+        mask = ldf_df["Avg Method"] == "Selected"
+        for col, val in ldf_series.items():
+            ldf_df.loc[mask, col] = val
+        self.ldf_exhibit[key] = ldf_df
+
+        # Recompute corresponding CDF row via DevelopmentConstant
+        tri = self.triangles[key]
+        dev = cl.DevelopmentConstant(patterns=patterns).fit(tri)
+        cdf_row = self.convert_triangle_to_df(dev.cdf_, index_name="Avg Method")
+        cdf_row["Avg Method"] = "Selected"
+
+        cdf_df = self.cdf_exhibit[key].copy()
+        cdf_mask = cdf_df["Avg Method"] == "Selected"
+        cdf_df.loc[cdf_mask, cdf_row.columns[1:]] = cdf_row.iloc[0, 1:].values
+        self.cdf_exhibit[key] = cdf_df
 
     def track_development_model(
         self,
@@ -452,6 +515,10 @@ class ReservingAppTriangle:
     ) -> Dict[Tuple[Optional[str], str], Dict[str, cl.Pipeline]]:
         """Fit ``development_method`` to each triangle and store the results.
 
+        User-selected LDFs supplied via :meth:`apply_selected_ldfs` are
+        honored for both methods by inserting a ``DevelopmentConstant`` step
+        when patterns are available.
+
         Parameters
         ----------
         development_method:
@@ -482,8 +549,13 @@ class ReservingAppTriangle:
         method = development_method.lower()
 
         for key, tri in self.triangles.items():
+            patterns = self.custom_ldfs.get(key)
+
             if method == "chainladder":
-                pipe = cl.Pipeline([("chainladder", cl.Chainladder())]).fit(tri)
+                steps = [("chainladder", cl.Chainladder())]
+                if patterns:
+                    steps.insert(0, ("selected", cl.DevelopmentConstant(patterns=patterns)))
+                pipe = cl.Pipeline(steps).fit(tri)
             elif method == "cape_cod":
                 if prem_col is None:
                     raise ValueError(
@@ -495,7 +567,10 @@ class ReservingAppTriangle:
                     raise ValueError(
                         f"No premium triangle available for group {group_title}"
                     )
-                pipe = cl.Pipeline([("cape_cod", cl.CapeCod())]).fit(
+                steps = [("cape_cod", cl.CapeCod())]
+                if patterns:
+                    steps.insert(0, ("selected", cl.DevelopmentConstant(patterns=patterns)))
+                pipe = cl.Pipeline(steps).fit(
                     tri, sample_weight=prem_tri.latest_diagonal
                 )
             else:

--- a/tests/test_development_constant.py
+++ b/tests/test_development_constant.py
@@ -1,0 +1,54 @@
+import os
+import sys
+
+import pandas as pd
+import chainladder as cl
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from helper_functions import ReservingAppTriangle
+
+
+def build_triangle():
+    data = pd.DataFrame(
+        {
+            "origin": [2018, 2018, 2019, 2019],
+            "development": [2019, 2020, 2020, 2021],
+            "loss": [100, 150, 80, 120],
+            "prem": [200, 200, 180, 180],
+        }
+    )
+    return ReservingAppTriangle(
+        data, origin="origin", development="development", value_cols=["loss", "prem"]
+    )
+
+
+def _apply_default_selected(tri, key):
+    ldf_series = (
+        tri.ldf_exhibit[key]
+        .loc[tri.ldf_exhibit[key]["Avg Method"] == "Volume Weighted"]
+        .iloc[0, 1:]
+        .fillna(1.0)
+        .astype(float)
+    )
+    tri.apply_selected_ldfs(key, ldf_series)
+
+
+def test_chainladder_uses_selected_ldfs():
+    tri = build_triangle()
+    key = (None, "loss")
+    _apply_default_selected(tri, key)
+    models = tri.get_development_model("chainladder")
+    pipe = models[key]["chainladder"]
+    assert "selected" in pipe.named_steps
+    assert isinstance(pipe.named_steps["selected"], cl.DevelopmentConstant)
+
+
+def test_cape_cod_uses_selected_ldfs():
+    tri = build_triangle()
+    key = (None, "loss")
+    _apply_default_selected(tri, key)
+    models = tri.get_development_model("cape_cod", prem_col="prem")
+    pipe = models[key]["cape_cod"]
+    assert "selected" in pipe.named_steps
+    assert isinstance(pipe.named_steps["selected"], cl.DevelopmentConstant)
+


### PR DESCRIPTION
## Summary
- ensure Cape Cod models honor user-selected LDFs via DevelopmentConstant
- add regression tests for chainladder and cape cod custom LDF pipelines

## Testing
- `python -m py_compile app.py helper_functions.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ec462d2e8833092a3018e9eec8f7c