### PR TITLE
Handle missing custom LDF keys

### DIFF
--- a/app.py
+++ b/app.py
@@ -56,9 +56,14 @@ def main() -> None:
         group_cols=group_cols,
         cumulative=True,
     )
-    # Reapply any user-selected LDFs stored in session state before fitting models
-    for key, ldf_dict in st.session_state.get("custom_ldfs", {}).items():
-        utils.apply_selected_ldfs(key, pd.Series(ldf_dict))
+    # Reapply any user-selected LDFs stored in session state before fitting models.
+    # Keys from prior selections may no longer exist when the user changes
+    # value/grouping options, so ignore and remove stale entries.
+    for key, ldf_dict in list(st.session_state.get("custom_ldfs", {}).items()):
+        if key in utils.ldf_exhibit:
+            utils.apply_selected_ldfs(key, pd.Series(ldf_dict))
+        else:
+            del st.session_state["custom_ldfs"][key]
 
     utils.fit_development_model("chainladder", experiment_name="Basic Reserving Models")
     if prem_col:
@@ -107,16 +112,16 @@ def main() -> None:
                 ldf_df = utils.ldf_exhibit[ldf_key]
                 # Enable editing only for the "Selected" row and keep the
                 # ``Avg Method`` column read-only so users can overwrite the
-                # LDF values.
+                # LDF values. Visually shade non-editable rows gray so users
+                # know they are locked.
                 row_disabled = ldf_df["Avg Method"] != "Selected"
-                edited_ldf_df = st.data_editor(
+                edited_ldf_df = custom_data_editor(
                     ldf_df,
                     key=f"ldf_{group_title}_{val_col}",
                     disabled=row_disabled,
                     column_config={
                         "Avg Method": st.column_config.TextColumn(disabled=True)
                     },
-                    hide_index=True,
                 )
                 utils.ldf_exhibit[ldf_key] = edited_ldf_df
                 selected_row = (

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -153,6 +153,80 @@ def custom_st_dataframe(df: pd.DataFrame) -> None:
     st.dataframe(df, hide_index=True, column_config=column_config)
 
 
+def custom_data_editor(
+    df: pd.DataFrame,
+    disabled: pd.Series | list | tuple | None = None,
+    column_config: dict | None = None,
+    **kwargs,
+) -> pd.DataFrame:
+    """Display ``df`` in ``st.data_editor`` with numeric formatting and row shading.
+
+    Parameters
+    ----------
+    df:
+        Data to display.
+    disabled:
+        Optional row-level disabled mask. Disabled rows are shaded gray to
+        indicate they are not editable.
+    column_config:
+        Optional Streamlit ``column_config`` mapping. Numeric columns that are
+        not explicitly configured receive default formatting.
+    **kwargs:
+        Additional keyword arguments forwarded to ``st.data_editor``.
+
+    Returns
+    -------
+    pd.DataFrame
+        The DataFrame returned by ``st.data_editor``.
+    """
+
+    index_levels = df.index.nlevels
+    df = df.copy()
+    df.columns = df.columns.map(str)
+
+    index_cols = list(df.columns[:index_levels])
+    numeric_cols: list[str] = []
+
+    for col in df.columns:
+        if col in index_cols:
+            continue
+        converted = pd.to_numeric(df[col], errors="coerce")
+        if converted.notna().any():
+            df[col] = converted
+            numeric_cols.append(col)
+
+    df[numeric_cols] = df[numeric_cols].apply(pd.to_numeric, errors="coerce")
+
+    user_cfg = column_config or {}
+    column_config = {}
+    for col in numeric_cols:
+        if col not in user_cfg:
+            max_val = df[col].abs().max()
+            fmt = "localized" if max_val > 999 else "%.2f"
+            column_config[col] = st.column_config.NumberColumn(format=fmt)
+    column_config.update(user_cfg)
+
+    disabled_rows = None
+    if isinstance(disabled, (pd.Series, list, tuple)):
+        disabled_rows = pd.Series(disabled, index=df.index)
+        styled_df = df.style.apply(
+            lambda row: ["background-color: #f0f0f0" if disabled_rows.loc[row.name] else ""]
+            * len(row),
+            axis=1,
+        )
+        return st.data_editor(
+            styled_df,
+            disabled=disabled_rows,
+            column_config=column_config,
+            hide_index=True,
+            **kwargs,
+        )
+
+    return st.data_editor(
+        df, disabled=disabled, column_config=column_config, hide_index=True, **kwargs
+    )
+
+
 class ReservingAppTriangle:
     """Utility helpers for actuarial reserving tasks.
 
@@ -448,6 +522,10 @@ class ReservingAppTriangle:
     ) -> None:
         """Update exhibits with user selected LDFs for ``key``.
 
+        If ``key`` is not present the call is ignored, allowing callers to
+        safely reapply previously stored selections even after the available
+        value or grouping options change.
+
         Parameters
         ----------
         key:
@@ -456,6 +534,12 @@ class ReservingAppTriangle:
             Series of LDF values indexed by development period labels, e.g.
             ``"12-24"``.
         """
+        if (
+            key not in self.ldf_exhibit
+            or key not in self.cdf_exhibit
+            or key not in self.triangles
+        ):
+            return
 
         # Normalize the Series to float values and construct pattern dict
         ldf_series = ldf_series.astype(float)
@@ -465,8 +549,7 @@ class ReservingAppTriangle:
         # Update LDF exhibit row
         ldf_df = self.ldf_exhibit[key].copy()
         mask = ldf_df["Avg Method"] == "Selected"
-        for col, val in ldf_series.items():
-            ldf_df.loc[mask, col] = val
+        ldf_df.loc[mask, ldf_series.index] = ldf_series.values
         self.ldf_exhibit[key] = ldf_df
 
         # Recompute corresponding CDF row via DevelopmentConstant

--- a/tests/test_development_constant.py
+++ b/tests/test_development_constant.py
@@ -52,3 +52,31 @@ def test_cape_cod_uses_selected_ldfs():
     assert "selected" in pipe.named_steps
     assert isinstance(pipe.named_steps["selected"], cl.DevelopmentConstant)
 
+
+def test_apply_selected_ldfs_ignores_missing_keys():
+    data = pd.DataFrame(
+        {
+            "origin": [2018, 2018, 2019, 2019],
+            "development": [2019, 2020, 2020, 2021],
+            "loss": [100, 150, 80, 120],
+            "prem": [200, 200, 180, 180],
+        }
+    )
+    # First triangle with loss to obtain an LDF series
+    tri_loss = ReservingAppTriangle(
+        data, origin="origin", development="development", value_cols=["loss"]
+    )
+    key_loss = (None, "loss")
+    ldf_series = (
+        tri_loss.ldf_exhibit[key_loss]
+        .loc[tri_loss.ldf_exhibit[key_loss]["Avg Method"] == "Volume Weighted"]
+        .iloc[0, 1:]
+    )
+
+    # Second triangle excludes loss; applying with old key should be a no-op
+    tri_prem = ReservingAppTriangle(
+        data, origin="origin", development="development", value_cols=["prem"]
+    )
+    tri_prem.apply_selected_ldfs(key_loss, ldf_series)
+    assert key_loss not in tri_prem.custom_ldfs
+


### PR DESCRIPTION
## Summary
- Avoid errors when reapplying stored LDF selections for groups/values that no longer exist
- Grey out non-editable LDF rows and centralize the styling in a reusable `custom_data_editor`
- Vectorize and document `apply_selected_ldfs` updates for robustness

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fba0d91f08330a4942157cb709420